### PR TITLE
feat: add browser pricing scraper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ past. Copy one into your project and change the parts you care about.
 | [browser-stealth-proxy-ts](examples/browser-stealth-proxy-ts) | TypeScript | Stealth mode + residential proxy egress |
 | [browser-profiles-ts](examples/browser-profiles-ts) | TypeScript | Log in once, reuse the session forever |
 | [browser-session-recording-py](examples/browser-session-recording-py) | Python | Record a session, download the replay |
+| [browser-pricing-scraper-py](examples/browser-pricing-scraper-py) | Python | Scrape a SaaS pricing page and export tiered pricing to CSV |
 
 ### Sandbox
 

--- a/examples/browser-pricing-scraper-py/.env.example
+++ b/examples/browser-pricing-scraper-py/.env.example
@@ -1,0 +1,10 @@
+SOLARI_API_KEY=slr_live_...
+# Optional overrides — point the scraper at any SaaS pricing page.
+# TARGET_URL=https://example.com/pricing
+# OUTPUT_FILE=pricing.csv
+# PRICING_CARD_SELECTOR=.solari-pricing-plan
+# PRICING_NAME_SELECTOR=.solari-pricing-plan-name
+# PRICING_PRICE_SELECTOR=.solari-pricing-price-value
+# PRICING_SUFFIX_SELECTOR=.solari-pricing-price-suffix
+# PRICING_DESC_SELECTOR=.solari-pricing-description
+# PRICING_FEATURES_SELECTOR=.solari-pricing-feature-list li span:last-child

--- a/examples/browser-pricing-scraper-py/README.md
+++ b/examples/browser-pricing-scraper-py/README.md
@@ -1,0 +1,33 @@
+# Browser pricing scraper (Python)
+
+Scrape a live SaaS pricing page and export tiered plans to CSV.
+
+This is a common competitive-intelligence workflow: point a cloud browser at a
+pricing page, wait for the plan cards to render, extract names, prices,
+descriptions, and feature lists, then write a structured `pricing.csv`.
+
+The target URL and CSS selectors are configurable via environment variables, so
+you can reuse the script for any pricing page.
+
+## Run
+
+```bash
+cd examples/browser-pricing-scraper-py
+pip install -r requirements.txt
+export SOLARI_API_KEY=slr_live_...   # https://console.getsolari.com
+python main.py
+```
+
+## What it does
+
+1. Loads `https://getsolari.com/pricing` (or `TARGET_URL`).
+2. Waits for the pricing grid to render.
+3. Extracts each plan's name, price, description, and bullet features.
+4. Writes `pricing.csv`.
+
+## Customize
+
+Copy `.env.example` to `.env` and adjust the selectors for the pricing page you
+want to scrape.
+
+Source: [`main.py`](main.py)

--- a/examples/browser-pricing-scraper-py/main.py
+++ b/examples/browser-pricing-scraper-py/main.py
@@ -1,0 +1,85 @@
+"""Pricing scraper — extract tiered SaaS pricing from a live page to CSV.
+
+A realistic competitive-intelligence workflow in Solari's cloud browser:
+load a pricing page, wait for the plan cards to render, extract names,
+prices, descriptions, and feature lists, then write a structured CSV.
+
+The target and selectors default to https://getsolari.com/pricing but are
+overridable via environment variables so the same script can point at any
+SaaS pricing page.
+"""
+
+import asyncio
+import csv
+import os
+
+from solari_browser import Solari
+
+DEFAULT_TARGET = "https://getsolari.com/pricing"
+
+SELECTORS = {
+    "card": os.getenv("PRICING_CARD_SELECTOR", ".solari-pricing-plan"),
+    "name": os.getenv("PRICING_NAME_SELECTOR", ".solari-pricing-plan-name"),
+    "price_value": os.getenv("PRICING_PRICE_SELECTOR", ".solari-pricing-price-value"),
+    "price_suffix": os.getenv("PRICING_SUFFIX_SELECTOR", ".solari-pricing-price-suffix"),
+    "description": os.getenv("PRICING_DESC_SELECTOR", ".solari-pricing-description"),
+    "features": os.getenv(
+        "PRICING_FEATURES_SELECTOR",
+        ".solari-pricing-feature-list li span:last-child",
+    ),
+}
+
+
+async def extract_plan(card) -> dict:
+    name = await card.locator(SELECTORS["name"]).first.inner_text()
+    price = await card.locator(SELECTORS["price_value"]).first.inner_text()
+    suffix = await card.locator(SELECTORS["price_suffix"]).first.inner_text()
+    description = await card.locator(SELECTORS["description"]).first.inner_text()
+    features = await card.locator(SELECTORS["features"]).all_inner_texts()
+
+    return {
+        "plan": name.strip(),
+        "price": f"{price.strip()} {suffix.strip()}".strip(),
+        "description": description.strip(),
+        "features": " | ".join(f.strip() for f in features),
+    }
+
+
+async def extract_plans(page) -> list[dict]:
+    target = os.getenv("TARGET_URL", DEFAULT_TARGET)
+    await page.goto(target)
+
+    # Wait for the pricing grid before querying, so the script is stable on
+    # real sites where cards render after the initial load.
+    await page.locator(SELECTORS["card"]).first.wait_for(timeout=15000)
+
+    cards = await page.locator(SELECTORS["card"]).all()
+    plans = [await extract_plan(card) for card in cards]
+    return plans
+
+
+async def main() -> None:
+    solari = Solari(api_key=os.environ["SOLARI_API_KEY"])
+    browser = await solari.launch()
+    try:
+        page = await browser.new_page()
+        plans = await extract_plans(page)
+
+        output_file = os.getenv("OUTPUT_FILE", "pricing.csv")
+        with open(output_file, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(
+                f,
+                fieldnames=["plan", "price", "description", "features"],
+            )
+            writer.writeheader()
+            writer.writerows(plans)
+
+        print(f"wrote {len(plans)} plans to {output_file}")
+        for plan in plans:
+            print(f"  - {plan['plan']}: {plan['price']}")
+    finally:
+        await browser.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/browser-pricing-scraper-py/requirements.txt
+++ b/examples/browser-pricing-scraper-py/requirements.txt
@@ -1,0 +1,1 @@
+solari-browser>=0.1.2


### PR DESCRIPTION
## Summary

- Adds a new `examples/browser-pricing-scraper-py` Python example to the cookbook.
- Demonstrates a realistic competitive-intelligence workflow: load a live SaaS pricing page in a Solari cloud browser, extract tiered plan names, prices, descriptions, and features, and export them to `pricing.csv`.
- Defaults to `https://getsolari.com/pricing` with configurable target URL and CSS selectors via environment variables, so the same script can be pointed at any pricing page.

## What changed

- `examples/browser-pricing-scraper-py/main.py` — complete runnable scraper.
- `examples/browser-pricing-scraper-py/README.md` — usage and customization notes.
- `examples/browser-pricing-scraper-py/requirements.txt` — `solari-browser>=0.1.2`.
- `examples/browser-pricing-scraper-py/.env.example` — optional selector overrides.
- `README.md` — adds the new example to the Cloud browser table.

## Test plan

- [x] `python3 -m py_compile main.py` passes.
- [ ] End-to-end run with a real `SOLARI_API_KEY` (I did not have a key to test the live API call).

## Known risks

- The default CSS selectors target the current Solari pricing page DOM. If the marketing site redesigns, the selectors may need to be updated or the user can override them with environment variables.
