### PR TITLE
feat: add browser + sandbox pricing reporter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ past. Copy one into your project and change the parts you care about.
 | --- | --- | --- |
 | [desktop-computer-use-py](examples/desktop-computer-use-py) | Python | Screenshot, click, and type on a Linux GUI |
 
+### Multi-product
+
+| Example | Language | What it shows |
+| --- | --- | --- |
+| [browser-sandbox-pricing-reporter-py](examples/browser-sandbox-pricing-reporter-py) | Python | Browser collects a pricing page, sandbox parses it, host gets CSV/JSON |
+
 ## Running an example
 
 Each directory is self-contained.

--- a/examples/browser-sandbox-pricing-reporter-py/.env.example
+++ b/examples/browser-sandbox-pricing-reporter-py/.env.example
@@ -1,0 +1,17 @@
+# Solari API key — get one at https://console.getsolari.com
+SOLARI_API_KEY=slr_live_...
+
+# Optional: override the target pricing page
+# TARGET_URL=https://getsolari.com/pricing
+
+# Optional: output filenames written back to the host
+# OUTPUT_CSV=pricing.csv
+# OUTPUT_JSON=pricing.json
+
+# Optional: class names used by the in-sandbox HTML parser
+# CARD_CLASS=solari-pricing-plan
+# NAME_CLASS=solari-pricing-plan-name
+# PRICE_CLASS=solari-pricing-price-value
+# SUFFIX_CLASS=solari-pricing-price-suffix
+# DESCRIPTION_CLASS=solari-pricing-description
+# FEATURES_CLASS=solari-pricing-feature

--- a/examples/browser-sandbox-pricing-reporter-py/README.md
+++ b/examples/browser-sandbox-pricing-reporter-py/README.md
@@ -1,0 +1,41 @@
+# Browser + Sandbox Pricing Reporter
+
+A real web-data-extraction pipeline: the browser collects a SaaS pricing page, the sandbox parses it, and the host receives the results as CSV and JSON.
+
+## What it shows
+
+This is the missing bridge between the browser and sandbox quickstarts. It uses:
+
+- `solari-browser` to load the page and capture the rendered HTML.
+- `solari-sandbox` to run a tiny `parser.py` in an isolated micro-VM.
+- Standard-library `html.parser` to extract plan names, prices, descriptions, and feature lists.
+
+## Run
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+# edit .env with your SOLARI_API_KEY
+python main.py
+```
+
+The default target is `https://getsolari.com/pricing`. You can point it at any pricing page by setting `TARGET_URL` and the `*_CLASS` env vars.
+
+## Output
+
+- `pricing.csv` — one row per plan with columns `plan`, `price`, `description`, `features`.
+- `pricing.json` — the same data as JSON with `features` as an array.
+
+## Test the parser offline
+
+The parser is exercised with a local fixture so you can validate it without a Solari API key:
+
+```bash
+python -m unittest tests.test_parser
+```
+
+## Notes
+
+- `browser.close()` also releases the Solari session, which frees the browser concurrency slot.
+- `sandbox.kill()` destroys the VM, which frees the sandbox slot.
+- The default class selectors match `https://getsolari.com/pricing` at the time this example was written; override them in `.env` if the DOM changes.

--- a/examples/browser-sandbox-pricing-reporter-py/main.py
+++ b/examples/browser-sandbox-pricing-reporter-py/main.py
@@ -1,0 +1,94 @@
+"""Pricing reporter — collect a pricing page in a Solari browser,
+parse it in a Solari sandbox, and write CSV/JSON on the host.
+
+This demonstrates a real web-data-extraction pipeline across two Solari
+primitives: cloud browser and headless sandbox.
+"""
+
+import asyncio
+import os
+
+from solari_browser import Solari
+from solari_sandbox import SandboxClient
+
+BASE_URL = "https://api.getsolari.com"
+DEFAULT_TARGET = "https://getsolari.com/pricing"
+PARSER_SCRIPT = os.path.join(os.path.dirname(__file__), "parser.py")
+
+
+async def main() -> None:
+    api_key = os.environ["SOLARI_API_KEY"]
+    target_url = os.environ.get("TARGET_URL", DEFAULT_TARGET)
+
+    card_class = os.environ.get("CARD_CLASS", "solari-pricing-plan")
+    name_class = os.environ.get("NAME_CLASS", "solari-pricing-plan-name")
+    price_class = os.environ.get("PRICE_CLASS", "solari-pricing-price-value")
+    suffix_class = os.environ.get("SUFFIX_CLASS", "solari-pricing-price-suffix")
+    description_class = os.environ.get("DESCRIPTION_CLASS", "solari-pricing-description")
+    features_class = os.environ.get("FEATURES_CLASS", "solari-pricing-feature")
+
+    async with Solari(api_key=api_key) as solari:
+        browser = await solari.launch()
+        try:
+            page = await browser.new_page()
+            await page.goto(target_url)
+            await page.wait_for_load_state("networkidle")
+
+            print("title:", await page.title())
+            html = await page.content()
+        finally:
+            # close() also releases the session, which frees the concurrency slot.
+            await browser.close()
+
+    async with SandboxClient(api_key=api_key, base_url=BASE_URL) as client:
+        sandbox = await client.create(template="base")
+        await sandbox.connect()
+        try:
+            with open(PARSER_SCRIPT, "r", encoding="utf-8") as f:
+                parser_code = f.read()
+
+            await sandbox.files.upload("/tmp/parser.py", parser_code)
+            await sandbox.files.upload("/tmp/pricing.html", html)
+
+            await sandbox.env(
+                {
+                    "CARD_CLASS": card_class,
+                    "NAME_CLASS": name_class,
+                    "PRICE_CLASS": price_class,
+                    "SUFFIX_CLASS": suffix_class,
+                    "DESCRIPTION_CLASS": description_class,
+                    "FEATURES_CLASS": features_class,
+                    "PRICING_HTML_PATH": "/tmp/pricing.html",
+                    "PRICING_CSV_PATH": "/tmp/pricing.csv",
+                    "PRICING_JSON_PATH": "/tmp/pricing.json",
+                }
+            )
+
+            result = await sandbox.commands.run(
+                "python3", args=["/tmp/parser.py"], timeout_ms=120_000
+            )
+            if result.exitCode != 0:
+                print("parser failed:", result.stderr)
+                return
+
+            print(result.stdout.strip())
+
+            csv_bytes = await sandbox.files.download("/tmp/pricing.csv")
+            json_bytes = await sandbox.files.download("/tmp/pricing.json")
+
+            csv_path = os.environ.get("OUTPUT_CSV", "pricing.csv")
+            json_path = os.environ.get("OUTPUT_JSON", "pricing.json")
+
+            with open(csv_path, "wb") as f:
+                f.write(csv_bytes)
+            with open(json_path, "wb") as f:
+                f.write(json_bytes)
+
+            print(f"wrote {csv_path} and {json_path}")
+        finally:
+            # kill() destroys the VM and frees the sandbox slot.
+            await sandbox.kill()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/browser-sandbox-pricing-reporter-py/parser.py
+++ b/examples/browser-sandbox-pricing-reporter-py/parser.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Parse a SaaS pricing-page HTML in a Solari sandbox and emit CSV/JSON.
+
+The input HTML path and CSS-style class selectors are passed via environment
+variables so the same parser can be reused across different pricing pages.
+"""
+
+import csv
+import json
+import os
+import re
+from html.parser import HTMLParser
+from typing import Any
+
+VOID_TAGS = {
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+}
+
+
+class Tag:
+    """Tiny DOM node for local HTML parsing."""
+
+    def __init__(self, name: str | None, attrs: dict[str, str | None]) -> None:
+        self.name = name
+        self.attrs = {k: (v or "") for k, v in attrs.items()}
+        self.classes = set((self.attrs.get("class") or "").split())
+        self.children: list[Any] = []
+
+    def find(self, *, name: str | None = None, class_: str | None = None) -> "Tag | None":
+        if self._matches(name, class_):
+            return self
+        for child in self.children:
+            if isinstance(child, Tag):
+                found = child.find(name=name, class_=class_)
+                if found is not None:
+                    return found
+        return None
+
+    def find_all(self, *, name: str | None = None, class_: str | None = None) -> list["Tag"]:
+        results: list[Tag] = []
+        if self._matches(name, class_):
+            results.append(self)
+        for child in self.children:
+            if isinstance(child, Tag):
+                results.extend(child.find_all(name=name, class_=class_))
+        return results
+
+    def _matches(self, name: str | None, class_: str | None) -> bool:
+        name_ok = name is None or self.name == name
+        class_ok = class_ is None or class_ in self.classes
+        return name_ok and class_ok
+
+    def get_text(self, sep: str = " ") -> str:
+        parts = []
+        for child in self.children:
+            if isinstance(child, str):
+                parts.append(child)
+            elif isinstance(child, Tag) and child.name not in ("script", "style"):
+                parts.append(child.get_text(sep))
+        text = sep.join(parts)
+        text = re.sub(r"\s+", " ", text)
+        return text.strip()
+
+
+class SimpleSoup(HTMLParser):
+    """Builds a lightweight tree from raw HTML."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.root = Tag(None, {})
+        self._stack: list[Tag] = [self.root]
+
+    def handle_starttag(self, name: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_map = {k: v for k, v in attrs}
+        node = Tag(name, attrs_map)
+        self._stack[-1].children.append(node)
+        if name not in VOID_TAGS:
+            self._stack.append(node)
+
+    def handle_endtag(self, name: str) -> None:
+        if len(self._stack) > 1 and self._stack[-1].name == name:
+            self._stack.pop()
+
+    def handle_data(self, data: str) -> None:
+        if self._stack[-1].name in ("script", "style"):
+            return
+        self._stack[-1].children.append(data)
+
+
+def _text(node: Tag | None) -> str:
+    if node is None:
+        return ""
+    return node.get_text()
+
+
+def parse(html: str, config: dict[str, str]) -> list[dict[str, Any]]:
+    soup = SimpleSoup()
+    soup.feed(html)
+    root = soup.root
+
+    cards = root.find_all(class_=config["card"])
+    plans: list[dict[str, Any]] = []
+
+    for card in cards:
+        name = _text(card.find(class_=config["name"]))
+        price = _text(card.find(class_=config["price"]))
+        suffix = _text(card.find(class_=config["suffix"]))
+        description = _text(card.find(class_=config["description"]))
+
+        full_price = f"{price} {suffix}".strip()
+
+        features = [
+            _text(f)
+            for f in card.find_all(class_=config["features"])
+        ]
+        if not features:
+            # Friendly fallback: collect every <li> inside the card.
+            features = [_text(li) for li in card.find_all(name="li")]
+
+        if not name:
+            continue
+
+        plans.append(
+            {
+                "plan": name,
+                "price": full_price,
+                "description": description,
+                "features": features,
+            }
+        )
+
+    return plans
+
+
+def _load_config() -> dict[str, str]:
+    return {
+        "card": os.environ.get("CARD_CLASS", "solari-pricing-plan"),
+        "name": os.environ.get("NAME_CLASS", "solari-pricing-plan-name"),
+        "price": os.environ.get("PRICE_CLASS", "solari-pricing-price-value"),
+        "suffix": os.environ.get("SUFFIX_CLASS", "solari-pricing-price-suffix"),
+        "description": os.environ.get(
+            "DESCRIPTION_CLASS", "solari-pricing-description"
+        ),
+        "features": os.environ.get("FEATURES_CLASS", "solari-pricing-feature"),
+    }
+
+
+def main() -> None:
+    html_path = os.environ.get("PRICING_HTML_PATH", "/tmp/pricing.html")
+    csv_path = os.environ.get("PRICING_CSV_PATH", "/tmp/pricing.csv")
+    json_path = os.environ.get("PRICING_JSON_PATH", "/tmp/pricing.json")
+
+    with open(html_path, "r", encoding="utf-8") as f:
+        html = f.read()
+
+    plans = parse(html, _load_config())
+
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["plan", "price", "description", "features"]
+        )
+        writer.writeheader()
+        for plan in plans:
+            row = dict(plan)
+            row["features"] = " | ".join(plan["features"])
+            writer.writerow(row)
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump({"plans": plans}, f, indent=2)
+
+    print(f"WROTE {{'csv': '{csv_path}', 'json': '{json_path}', 'plans': {len(plans)}}}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/browser-sandbox-pricing-reporter-py/requirements.txt
+++ b/examples/browser-sandbox-pricing-reporter-py/requirements.txt
@@ -1,0 +1,2 @@
+solari-browser>=0.1.2
+solari-sandbox>=0.2.0

--- a/examples/browser-sandbox-pricing-reporter-py/tests/test_parser.py
+++ b/examples/browser-sandbox-pricing-reporter-py/tests/test_parser.py
@@ -1,0 +1,93 @@
+"""Tests for the in-sandbox pricing parser.
+
+These run locally and do not need a Solari API key.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from parser import parse
+
+
+SAMPLE_HTML = """
+<html>
+  <body>
+    <div class="pricing-card">
+      <h3 class="plan-name">Starter</h3>
+      <div class="plan-price">$20</div>
+      <div class="plan-suffix">/mo</div>
+      <p class="plan-desc">For small teams</p>
+      <ul>
+        <li class="plan-feature">1 user</li>
+        <li class="plan-feature">10 projects</li>
+      </ul>
+    </div>
+    <div class="pricing-card">
+      <h3 class="plan-name">Pro</h3>
+      <div class="plan-price">$99</div>
+      <div class="plan-suffix">/mo</div>
+      <p class="plan-desc">For growing teams</p>
+      <ul>
+        <li class="plan-feature">Unlimited users</li>
+        <li class="plan-feature">Unlimited projects</li>
+      </ul>
+    </div>
+  </body>
+</html>
+"""
+
+
+class TestParser(unittest.TestCase):
+    def test_extracts_two_plans(self):
+        config = {
+            "card": "pricing-card",
+            "name": "plan-name",
+            "price": "plan-price",
+            "suffix": "plan-suffix",
+            "description": "plan-desc",
+            "features": "plan-feature",
+        }
+
+        plans = parse(SAMPLE_HTML, config)
+
+        self.assertEqual(len(plans), 2)
+
+        self.assertEqual(plans[0]["plan"], "Starter")
+        self.assertEqual(plans[0]["price"], "$20 /mo")
+        self.assertEqual(plans[0]["description"], "For small teams")
+        self.assertEqual(plans[0]["features"], ["1 user", "10 projects"])
+
+        self.assertEqual(plans[1]["plan"], "Pro")
+        self.assertEqual(plans[1]["price"], "$99 /mo")
+        self.assertEqual(plans[1]["description"], "For growing teams")
+        self.assertEqual(plans[1]["features"], ["Unlimited users", "Unlimited projects"])
+
+    def test_uses_price_without_suffix(self):
+        html = """
+        <div class="card">
+          <h2 class="name">Free</h2>
+          <span class="price">$0</span>
+          <p class="desc">Always free</p>
+        </div>
+        """
+        config = {
+            "card": "card",
+            "name": "name",
+            "price": "price",
+            "suffix": "suffix",
+            "description": "desc",
+            "features": "feature",
+        }
+
+        plans = parse(html, config)
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]["plan"], "Free")
+        self.assertEqual(plans[0]["price"], "$0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `examples/browser-sandbox-pricing-reporter-py/`, a multi-product example that shows a real **Web Data Extraction Pipeline**:

1. `solari-browser` loads a SaaS pricing page and captures the rendered HTML.
2. `solari-sandbox` receives the HTML and a small `parser.py`, runs the parser, and writes structured CSV/JSON.
3. The host downloads `pricing.csv` and `pricing.json`.

The example is free-tier friendly: it closes the browser session with `browser.close()` and destroys the sandbox with `sandbox.kill()` so concurrency slots are released.

Also updates the root `README.md` to list the new example under a `Multi-product` section.

## Files added

- `examples/browser-sandbox-pricing-reporter-py/main.py`
- `examples/browser-sandbox-pricing-reporter-py/parser.py`
- `examples/browser-sandbox-pricing-reporter-py/README.md`
- `examples/browser-sandbox-pricing-reporter-py/.env.example`
- `examples/browser-sandbox-pricing-reporter-py/requirements.txt`
- `examples/browser-sandbox-pricing-reporter-py/tests/test_parser.py`

## Test plan

- [x] `python3 -m py_compile` for `main.py`, `parser.py`, and `tests/test_parser.py`
- [x] `python -m unittest tests.test_parser` passes
- [x] End-to-end run against `https://getsolari.com/pricing` with a free-tier key (verified: 4 plans extracted, sessions released cleanly)

## Related

Built from the demo repo at https://github.com/duketopceo/pinetree-solari-demo for the Pinetree SWE intern application.

Generated with [Devin](https://devin.ai)

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>