### PR TITLE
Fix the profiles example so the profile actually restores

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Things that cost you an afternoon if you meet them cold:
 - **TypeScript: call `await solari.close()`.** The browser client keeps a
   loopback proxy open for connection retries. Skip the close and your script
   prints its output and then hangs forever instead of exiting.
+- **A profile does not seed the browser on its own.** `launch({ profileId })` puts the
+  stored state on `session.storageState` and stops there. Pass it to
+  `newContext({ storageState })` or every run starts anonymous while looking logged in.
+  `addCookies()` is not a substitute: it restores the cookies and drops localStorage.
 - **Recording is per session, not per account.** Pass `recording: true` when you
   create the session; without it the replay endpoint 404s forever. The upload is
   async after release, so poll for ~30s before giving up.

--- a/examples/browser-profiles-ts/README.md
+++ b/examples/browser-profiles-ts/README.md
@@ -1,8 +1,10 @@
 # Persistent profiles (TypeScript)
 
-Log in once, reuse the session forever. A profile stores cookies + localStorage server-side; attach it with `profileId` and the browser starts already logged in.
+Log in once, reuse the session forever. A profile stores cookies + localStorage server-side; attach it with `profileId`, pass the state it returns to your context, and the browser starts already logged in.
 
-Run it twice — the visit counter survives because the profile is saved between runs. Attaching a profile does not auto-save it; you must call `profiles.save()`.
+Run it twice: the visit counter survives because the profile is saved between runs.
+
+Two halves are easy to miss, and each one on its own leaves you with a counter stuck at 1. Attaching a profile does not auto-save it, so you must call `profiles.save()`. And attaching a profile does not seed the browser either, so `session.storageState` has to reach `newContext({ storageState })`.
 
 ## Run
 

--- a/examples/browser-profiles-ts/index.ts
+++ b/examples/browser-profiles-ts/index.ts
@@ -2,8 +2,9 @@
  * Persistent profiles — log in once, reuse the session forever.
  *
  * A profile stores cookies + localStorage server-side. Attach it with
- * `profileId` and the browser starts already logged in, so you stop paying the
- * login (and the 2FA, and the bot check) on every run.
+ * `profileId` and pass the returned state to your context, and the browser
+ * starts already logged in, so you stop paying the login (and the 2FA, and the
+ * bot check) on every run.
  *
  * Run this file twice: the first run logs in and saves, the second reuses it.
  */
@@ -19,7 +20,14 @@ console.log(existing ? `reusing profile ${profile.id}` : `created profile ${prof
 
 const browser = await solari.launch({ profileId: profile.id })
 try {
-  const page = await browser.newPage()
+  // Attaching a profile hands its state to `session.storageState`. It does not
+  // seed the browser, so the state has to go to the context you create. A page
+  // from `browser.newPage()` starts anonymous and the counter below never
+  // leaves 1, however many times you run this.
+  const context = await browser.newContext({
+    storageState: browser.session.storageState ?? undefined,
+  })
+  const page = await context.newPage()
 
   // This demo site echoes whatever is in localStorage/cookies back to you, so
   // you can see state survive between runs. Swap it for your real login flow.
@@ -34,7 +42,7 @@ try {
 
   // Persist whatever the browser accumulated. Without this the session's state
   // is discarded on release — attaching a profile does not auto-save it.
-  const state = await page.context().storageState()
+  const state = await context.storageState()
   const { version, sizeBytes } = await solari.profiles.save(profile.id, state)
   console.log(`saved profile v${version} (${sizeBytes} bytes)`)
 } finally {


### PR DESCRIPTION
`browser-profiles-ts` never restores the profile it saves. Run it unmodified against the live API three times:

```
created profile cmtint9gd01y7o101x3ssica7
visit #1 for this profile
saved profile v2 (106 bytes)

reusing profile cmtint9gd01y7o101x3ssica7
visit #1 for this profile
saved profile v3 (106 bytes)

reusing profile cmtint9gd01y7o101x3ssica7
visit #1 for this profile
saved profile v4 (106 bytes)
```

The profile is found and reused, and a new version is written every run, so nothing looks broken. The counter is read from localStorage, which comes up empty every time.

## Why

`launch({ profileId })` delivers the stored state to `session.storageState` and stops there. It does not seed the browser. A context from `browser.newPage()` comes up with neither cookies nor localStorage.

I checked the three ways a caller might reach for this:

| approach | cookies | localStorage |
| --- | --- | --- |
| `browser.newPage()` | no | no |
| `browser.newContext({ storageState: session.storageState })` | yes | yes |
| `context.addCookies(state.cookies)` | yes | no |

`addCookies()` is the near miss worth naming. It restores enough that a cookie-only login looks fine, while any session keeping its token in localStorage fails quietly.

## The fix

Hand the state to the context at creation, which is what `Session.storageState` is on the type for:

```ts
const context = await browser.newContext({
  storageState: browser.session.storageState ?? undefined,
})
const page = await context.newPage()
```

Three runs on this branch, same command, fresh profile:

```
created profile cmtiqyorj01zro101uekyrzj4
visit #1 for this profile
saved profile v2 (106 bytes)

reusing profile cmtiqyorj01zro101uekyrzj4
visit #2 for this profile
saved profile v3 (106 bytes)

reusing profile cmtiqyorj01zro101uekyrzj4
visit #3 for this profile
saved profile v4 (106 bytes)
```

## Also in this PR

The example's README and its header comment both promised the old behaviour, so they are updated to match. I added the gotcha to the root README list as well, because this is the kind that costs more than an afternoon: the browser reports a healthy session and the automation runs as a stranger, with no error anywhere.
