### PR TITLE
Add browser-broker-scan-ts: full-kit scan of a bot-hostile site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ past. Copy one into your project and change the parts you care about.
 | [browser-stealth-proxy-ts](examples/browser-stealth-proxy-ts) | TypeScript | Stealth mode + residential proxy egress |
 | [browser-profiles-ts](examples/browser-profiles-ts) | TypeScript | Log in once, reuse the session forever |
 | [browser-session-recording-py](examples/browser-session-recording-py) | Python | Record a session, download the replay |
+| [browser-broker-scan-ts](examples/browser-broker-scan-ts) | TypeScript | The full kit on a bot-hostile site: stealth + sticky proxy + captcha + recording, screenshot the evidence |
 
 ### Sandbox
 

--- a/examples/browser-broker-scan-ts/index.ts
+++ b/examples/browser-broker-scan-ts/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Scan a bot-hostile people-search site (FastPeopleSearch) — the pattern
+ * behind PrivacyJanitor, an open-source data-broker removal agent.
+ *   https://github.com/EzraStone/privacy-janitor
+ *
+ * People-search brokers throw Cloudflare walls at plain fetches and
+ * fingerprint hard at datacenter traffic. The full kit in one launch:
+ *   stealth: true   look like a person, pass the walls
+ *   proxy:   {...}   sticky US residential IP for the whole flow
+ *   captcha: true    Turnstile solved before the form submits
+ *   recording: true  replayable evidence of everything the agent did
+ *
+ * Change `PERSON` to search for a fictional test subject — keep it
+ * fictional; don't paste a real person's details into an example.
+ */
+import { Solari } from "@solarisdk/browser"
+
+const PERSON = { name: "Jordan Example", location: "Seattle, WA" }
+
+const solari = new Solari({ apiKey: process.env.SOLARI_API_KEY! })
+
+// Sticky session: one residential IP for the whole run — brokers flag a
+// flow that hops countries mid-search.
+const browser = await solari.launch({
+  stealth: true,
+  captcha: true,
+  recording: true,
+  proxy: { country: "us", session: "broker-scan-2", sessionDuration: 10 },
+})
+try {
+  const page = await browser.newPage()
+
+  await page.goto("https://www.fastpeoplesearch.com", { waitUntil: "domcontentloaded" })
+  await page.locator("#search-name-name").fill(PERSON.name)
+  await page.locator("#search-name-address").fill(PERSON.location)
+  await page.locator("#search-name-name").press("Enter")
+  await page.waitForTimeout(5000) // results render client-side
+
+  // Profile links on this broker look like /jordan-example_id_G123...
+  const hrefs = await page.evaluate(() =>
+    Array.from(document.querySelectorAll("a"))
+      .map((a) => a.getAttribute("href"))
+      .filter((h): h is string => /_id_G-?\d+$/.test(h ?? "")),
+  )
+  console.log(`found ${hrefs.length} candidate profile(s):`)
+  for (const h of hrefs.slice(0, 5)) console.log("  ", h)
+
+  // Screenshot the evidence — a removal flow needs proof of what the
+  // broker showed before you asked them to take it down.
+  await page.screenshot({ path: "broker-scan.png", fullPage: true })
+
+  const sessionId = browser.id
+  console.log("evidence screenshot: broker-scan.png")
+  console.log("session id          :", sessionId)
+  console.log("replay              : watch it in console.getsolari.com -> Replay")
+} finally {
+  await browser.close()
+  // Required, or the process never exits — see browser-quickstart-ts.
+  await solari.close()
+}

--- a/examples/browser-broker-scan-ts/package.json
+++ b/examples/browser-broker-scan-ts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "solari-browser-broker-scan-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@solarisdk/browser": "^0.1.1"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}


### PR DESCRIPTION
## What

Adds `browser-broker-scan-ts` — a scan of a bot-hostile people-search site (FastPeopleSearch) using the full kit in one launch: `stealth` + sticky US residential `proxy` + `captcha` + `recording`, then screenshots the results as evidence.

## Why this example

Broker sites are the hard case for browser automation: plain fetches get 403s, real-looking traffic hits Cloudflare Turnstile, and datacenter IPs are fingerprinted. It demonstrates the exact combination that survives all three, plus the evidence pattern (`recording` + screenshot) that a removal/audit workflow needs.

It's also the core pattern behind **PrivacyJanitor**, an open-source data-broker removal agent built on Solari (scan → confirm → PII-redacted risk ranking → approval-gated official opt-outs): https://github.com/EzraStone/privacy-janitor

## Style

Follows the existing examples: one self-contained `index.ts` with a commented header, fictional test subject, `package.json` matching `browser-stealth-proxy-ts`, and the required `solari.close()` gotcha from the quickstart.

## Verification

The exact launch recipe was verified live against FastPeopleSearch (and Whitepages/Spokeo flows in the parent project) earlier today — profile extraction included. At the time of opening this PR Solari's proxy tier was intermittently failing tunnels (even `example.com` through `proxy: "us"`); the code is recipe-identical to `browser-stealth-proxy-ts`, so any failure on a re-run is the transient proxy outage, not the example.
