### PR TITLE
README: base sandbox ships Node 18; @solarisdk/browser needs >=20

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Things that cost you an afternoon if you meet them cold:
   binary named `ls -la`. Put argv in `args`, or run `sh -c` explicitly.
 - **`kill()`, not `close()`, ends a VM.** `close()` drops your local control
   channel; the VM keeps running until its idle timeout.
+- **The `base` sandbox template ships Node 18, but `@solarisdk/browser`
+  needs Node ≥ 20** (its patchright dependency). Code that only calls the
+  sandbox API is fine — but if your use case runs SDK code *inside* a
+  sandbox (agents building agents, CI-style reviews of repos that use
+  Solari), `npm install` crashes with EBADENGINE. Upgrade first:
+  `curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs`.
 - **`timeoutMs` is a rolling idle window**, not a hard deadline — it resets on
   every use.
 


### PR DESCRIPTION
Found this one in the field while building [Gauntlet](https://github.com/dubsquared/solari-gauntlet) (an AI code reviewer that runs submissions inside Solari sandboxes): any workflow that runs SDK-dependent code *inside* a sandbox — agents building agents, CI-style reviews of repos that themselves use Solari — hits an EBADENGINE crash on `npm install`, because the `base` template ships Node 18 while `@solarisdk/browser`'s patchright dependency wants Node ≥ 20.

The fix is a one-liner in the VM, but it costs an afternoon cold — exactly the kind of thing the README's gotchas section exists for, so this adds it there.

(For what it's worth, Gauntlet's planner discovered the workaround on its own during a self-review — it diagnosed the engine mismatch from the install failure and upgraded Node inside the VM to keep going. The gotcha is real.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)