### PR TITLE
Add browser-session-survival-ts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ past. Copy one into your project and change the parts you care about.
 | [browser-stealth-proxy-ts](examples/browser-stealth-proxy-ts) | TypeScript | Stealth mode + residential proxy egress |
 | [browser-profiles-ts](examples/browser-profiles-ts) | TypeScript | Log in once, reuse the session forever |
 | [browser-session-recording-py](examples/browser-session-recording-py) | Python | Record a session, download the replay |
+| [browser-session-survival-ts](examples/browser-session-survival-ts) | TypeScript | Sessions end after ~10 min; checkpoint, relaunch, re-enter the task |
 
 ### Sandbox
 

--- a/examples/browser-session-survival-ts/README.md
+++ b/examples/browser-session-survival-ts/README.md
@@ -1,0 +1,22 @@
+# Session survival (TypeScript)
+
+A Solari browser session ends about ten minutes after it starts, whatever you send it — six sessions measured from fully idle to a live screencast all ended 604–616 s after creation, and the sessions API kept reporting each dead one as `active` ([issue #25](https://github.com/solari-sdk/solari-cookbook/issues/25)). Any task longer than that dies in the middle.
+
+[`outlive`](https://github.com/Sy-D/outlive) makes the death survivable: it checkpoints cookies, localStorage and the URL, notices the death on the connection (never through the status API), launches a new browser with that state, and calls your task again with `ctx.attempt` and `ctx.resumedFrom`. Measured against the live API with twelve-minute tasks: a plain browser finished 0 of 5, outlive 5 of 5, losing 4.9 s of work at the median.
+
+What does not survive: the DOM and anything the page held in JavaScript. A task is written to be re-entered — checkpoint right after the step that must not run twice, and check for its effect on re-entry. The library puts that in the API instead of hiding it.
+
+## Run
+
+```bash
+cd examples/browser-session-survival-ts
+npm install
+export SOLARI_API_KEY=slr_live_...   # https://console.getsolari.com
+npm start
+```
+
+The task polls a page every 20 s for twelve minutes. Around the ten-minute mark the session ends; you see the relaunch and the re-entry in the log, and the run finishes with all 36 polls.
+
+Source: [`index.ts`](index.ts)
+
+Part of a series with [`handraise`](https://github.com/Sy-D/handraise) ([browser-human-handoff-ts](../browser-human-handoff-ts)), which handles the other way an agent stops: a human is needed.

--- a/examples/browser-session-survival-ts/index.ts
+++ b/examples/browser-session-survival-ts/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Session survival — a task that is longer than a Solari browser session.
+ *
+ * A Solari browser session ends about ten minutes after it starts, whatever
+ * you send it. Anything that runs longer dies mid-task, and the sessions API
+ * keeps reporting the dead session as active. `outlive()` checkpoints cookies,
+ * localStorage and the URL, notices the death on the connection, launches a
+ * new browser with that state, and calls your task again.
+ *
+ * What survives: cookies, localStorage, the URL. What does not: the DOM and
+ * anything the page held in JavaScript. So a task is written to be re-entered:
+ * `ctx.attempt` says how often it has been called, `ctx.resumedFrom` is set
+ * when a checkpoint was restored, and `ctx.checkpoint()` saves right after a
+ * step that must not run twice.
+ */
+import { Solari } from "@solarisdk/browser"
+import { outlive } from "outlive"
+
+const solari = new Solari({ apiKey: process.env.SOLARI_API_KEY! })
+
+// Twelve minutes of polling: longer than one session, by construction.
+const POLLS = 36
+const EVERY_MS = 20_000
+
+try {
+  const titles = await outlive(
+    solari,
+    async (page, ctx) => {
+      if (ctx.attempt > 1) {
+        console.log(`re-entered (attempt ${ctx.attempt}), resumed at ${ctx.resumedFrom?.url ?? "no checkpoint"}`)
+      }
+      if (!ctx.resumedFrom) {
+        // The expensive part — sign in, land on the page — happens once.
+        await page.goto("https://example.com/")
+        await ctx.checkpoint()
+      }
+
+      const seen: string[] = []
+      for (let i = 0; i < POLLS; i++) {
+        await page.reload()
+        seen.push(await page.title())
+        await new Promise((resolve) => setTimeout(resolve, EVERY_MS))
+      }
+      return seen
+    },
+    {
+      checkpointEveryMs: 30_000,
+      maxRelaunches: 5,
+      // One wide event per run: outcome, relaunches, checkpoints, lost work.
+      onEvent: (event) => console.log(JSON.stringify(event)),
+    },
+  )
+
+  console.log(`done: ${titles.length} polls across however many sessions it took`)
+} finally {
+  await solari.close()
+}

--- a/examples/browser-session-survival-ts/package.json
+++ b/examples/browser-session-survival-ts/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "solari-browser-session-survival-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@solarisdk/browser": "^0.1.3",
+    "outlive": "^0.1.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}


### PR DESCRIPTION
A task longer than a Solari browser session. Sessions end about ten minutes after creation whatever you send them (issue #25 has the measurements), so this example runs a twelve-minute polling task through that death with outlive (https://github.com/Sy-D/outlive): checkpoint cookies, localStorage and URL, notice the death on the connection, relaunch, re-enter the task with ctx.attempt / ctx.resumedFrom. Measured: baseline 0 of 5 such tasks complete, outlive 5 of 5, 4.9 s of work lost at the median.

Second example of a series with browser-human-handoff-ts (#24). outlive 0.1.0 is being published to npm today.