### PR TITLE
Add a Workers + raw CDP example: drive a browser without the SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 package-lock.json
 .env
+.dev.vars
+.wrangler/
 __pycache__/
 *.pyc
 .venv/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ past. Copy one into your project and change the parts you care about.
 | [browser-stealth-proxy-ts](examples/browser-stealth-proxy-ts) | TypeScript | Stealth mode + residential proxy egress |
 | [browser-profiles-ts](examples/browser-profiles-ts) | TypeScript | Log in once, reuse the session forever |
 | [browser-session-recording-py](examples/browser-session-recording-py) | Python | Record a session, download the replay |
+| [browser-workers-cdp-ts](examples/browser-workers-cdp-ts) | TypeScript | Drive a browser from a Cloudflare Worker, over raw CDP |
 
 ### Sandbox
 
@@ -69,6 +70,11 @@ Things that cost you an afternoon if you meet them cold:
   `await solari.close()` or the script printed its output and then hung forever.
   0.1.3 unrefs the listener — `browser.close()` alone now exits. Calling
   `solari.close()` is still fine and releases the client's pool immediately.
+- **The TypeScript SDK cannot run on an edge runtime.** It bundles a
+  Playwright fork that wants Node and raw TCP sockets, so Workers, Deno
+  Deploy and friends are out. Skip it: every session exposes a CDP endpoint,
+  and any runtime that can hold an outbound WebSocket can drive the browser
+  directly. See [browser-workers-cdp-ts](examples/browser-workers-cdp-ts).
 - **Recording is per session, not per account.** Pass `recording: true` when you
   create the session; without it the replay endpoint 404s forever. The upload is
   async after release, so poll for ~30s before giving up.

--- a/examples/browser-workers-cdp-ts/.dev.vars.example
+++ b/examples/browser-workers-cdp-ts/.dev.vars.example
@@ -1,0 +1,6 @@
+# Get a key at https://console.getsolari.com
+#
+# Workers read local secrets from .dev.vars, not .env. Copy this file to
+# .dev.vars and `wrangler dev` picks it up; in production the same name is a
+# secret you set with `wrangler secret put SOLARI_API_KEY`.
+SOLARI_API_KEY=slr_live_...

--- a/examples/browser-workers-cdp-ts/README.md
+++ b/examples/browser-workers-cdp-ts/README.md
@@ -1,0 +1,90 @@
+# Browser from a Cloudflare Worker, over raw CDP (TypeScript)
+
+Launch a cloud browser from a Worker, open a page, read it, release the session.
+No Node process anywhere in the path, and no `@solarisdk/browser` — the whole
+example has zero runtime dependencies.
+
+## Why this exists
+
+`@solarisdk/browser` bundles a Playwright fork, which wants a Node runtime and
+raw TCP sockets. Workers have neither, so the SDK cannot run there. The usual
+answer is to stand up a small Node service beside the Worker whose only job is
+to hold the browser: an extra hop on every action, an extra deploy, and an extra
+thing to page someone about at 3am.
+
+You don't need it. Solari exposes each session's Chrome DevTools Protocol
+endpoint, and a Worker can hold an outbound WebSocket — so the Worker can speak
+CDP directly. Playwright is a convenience over that protocol, not a requirement
+of it, and the subset you need to open a page and read it is about sixty lines.
+
+The same trick works from any WebSocket-capable edge runtime — Deno Deploy,
+Vercel Edge, Bun — for the same reason.
+
+## Run
+
+```bash
+cd examples/browser-workers-cdp-ts
+npm install
+cp .dev.vars.example .dev.vars       # then paste your key in
+npm start                            # wrangler dev, on http://localhost:8787
+```
+
+```bash
+curl 'http://localhost:8787/?url=https://example.com'
+{"url":"https://example.com/","title":"Example Domain","h1":"Example Domain","session":"ip-10-0-11-65:30d02860-...:1788615203191.YXHjXU3oaXz8It406fGZ9g"}
+```
+
+`npm run deploy` puts it on your own workers.dev subdomain; set the key there
+with `wrangler secret put SOLARI_API_KEY`.
+
+## The five things that bite
+
+All five are commented at the line where they happen in [`index.ts`](index.ts).
+
+1. **A Worker has no `new WebSocket(url)`.** You upgrade an outbound `fetch` —
+   `fetch(url, { headers: { Upgrade: "websocket" } })`, then read
+   `response.webSocket`. `fetch` will not accept a `ws://` URL, so swap the
+   scheme to `http://` first, and call `socket.accept()` or you never receive a
+   single message.
+2. **A CDP connection is the browser, not a page.** `Target.createTarget` then
+   `Target.attachToTarget` with `flatten: true`, and every command meant for
+   the page carries the session id that comes back. Send one without it and you
+   are addressing the browser, which will tell you the method does not exist.
+3. **Domains are opt-in and silent until enabled.** No `Page.enable`, no
+   `Page.loadEventFired` — and the navigation just looks like it hung.
+4. **`Page.navigate` resolves when the navigation starts**, not when the page is
+   ready. Subscribe to `Page.loadEventFired` *before* navigating, then await it,
+   or you will read `about:blank` off a fast page.
+5. **Closing the socket does not end the session.** It runs on, billing, until
+   its idle timeout. `DELETE /sessions/:id` in a `finally`, so a thrown error
+   cannot leak a browser.
+
+The session id is not a short token. It comes back as a composite string —
+worker host, session uuid, and more — so treat it as opaque: pass it around
+whole rather than parsing or truncating it.
+
+And one about the payload rather than the protocol: the create-session response
+carries the id as `sessionId` on the wire but as `id` on the SDKs' `Session`
+type, and `cdpEndpoint` is optional — when it is absent, derive it from
+`wsEndpoint` by swapping `/ws/` for `/cdp/`, which is what the SDKs do.
+
+## Where to take it
+
+- **A screenshot is one more call.** `Page.captureScreenshot` with
+  `{ format: "png" }` returns base64; put the bytes in R2 and you have evidence
+  a log line cannot give you.
+- **Status codes and console errors need `Network.enable` and `Log.enable`,**
+  then listen for `Network.responseReceived` and `Runtime.consoleAPICalled`.
+  This example's `once()` handles one event; a real run wants a listener set.
+- **Waiting for load is the weakest thing here.** A single-page app finishes
+  loading long before it finishes rendering. What actually works is a quiet
+  period: track in-flight requests from the `Network` events and wait for the
+  page to stop making them, with a floor and a ceiling.
+- **Anything longer than one request belongs in a Durable Object.** A fetch
+  handler that drives a ten-step journey holds a client connection open for the
+  whole thing. Put the loop in a DO, return a job id, and stream progress over
+  SSE.
+
+A production build of all four is [Forge](https://github.com/kurtiz/forge),
+which drives Solari this way to verify deployed web apps end to end —
+`apps/web/src/server/execution/` is this file grown up.

--- a/examples/browser-workers-cdp-ts/index.ts
+++ b/examples/browser-workers-cdp-ts/index.ts
@@ -1,0 +1,275 @@
+/**
+ * Drive a Solari browser from a Cloudflare Worker, over raw CDP.
+ *
+ * `@solarisdk/browser` bundles a Playwright fork, which wants a Node runtime
+ * and raw TCP sockets, so it cannot run on Workers. The usual workaround is to
+ * put a small Node service next to the Worker just to hold the browser — an
+ * extra hop, an extra deploy, and an extra thing to page someone about.
+ *
+ * You don't need it. Solari hands out each session's Chrome DevTools Protocol
+ * endpoint, and a Worker can hold an outbound WebSocket, so the Worker can
+ * speak CDP itself. That is this whole example: a REST call to get a session,
+ * about sixty lines of protocol, and no Node process anywhere in the path.
+ *
+ *     GET /?url=https://example.com
+ */
+
+type Env = { SOLARI_API_KEY: string }
+
+const SOLARI_API = "https://api.getsolari.com"
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const target =
+      new URL(request.url).searchParams.get("url") ?? "https://example.com"
+
+    const session = await createSession(env.SOLARI_API_KEY)
+    const cdp = await connect(session.cdpEndpoint)
+
+    try {
+      // A CDP connection is the *browser*, not a page. Open a tab, then attach
+      // to it. `flatten: true` multiplexes that tab's traffic down this same
+      // socket, tagged with a session id you must then pass on every command
+      // meant for the page — omit it and you are talking to the browser again,
+      // which will politely tell you the method does not exist.
+      const { targetId } = await cdp.send<{ targetId: string }>(
+        "Target.createTarget",
+        { url: "about:blank" },
+      )
+      const { sessionId } = await cdp.send<{ sessionId: string }>(
+        "Target.attachToTarget",
+        { targetId, flatten: true },
+      )
+
+      // Domains are opt-in and silent until enabled: `Page.loadEventFired`
+      // below never arrives without this line, and the navigation looks like
+      // it hung.
+      await cdp.send("Page.enable", {}, sessionId)
+      await cdp.send("Runtime.enable", {}, sessionId)
+
+      const loaded = cdp.once("Page.loadEventFired")
+      // `Page.navigate` resolves when the navigation *starts*, not when the
+      // page is ready. Read the DOM off the back of this promise and you read
+      // about:blank. Subscribe before navigating, so a fast page cannot fire
+      // the event before anyone is listening.
+      await cdp.send("Page.navigate", { url: target }, sessionId)
+      await loaded
+
+      return Response.json({
+        url: await evaluate<string>(cdp, sessionId, "location.href"),
+        title: await evaluate<string>(cdp, sessionId, "document.title"),
+        h1: await evaluate<string | null>(
+          cdp,
+          sessionId,
+          "document.querySelector('h1')?.innerText ?? null",
+        ),
+        session: session.sessionId,
+      })
+    } finally {
+      cdp.close()
+      // Sessions are billable and your plan caps how many run at once, so the
+      // release is unconditional — a thrown error must not leak a browser.
+      // Closing the socket does NOT end the session; the VM runs on until its
+      // idle timeout. In a real handler, hand this to `ctx.waitUntil()` so the
+      // response is not waiting on it.
+      await releaseSession(env.SOLARI_API_KEY, session.sessionId)
+    }
+  },
+} satisfies ExportedHandler<Env>
+
+/* -------------------------------------------------------------------------- */
+/* The REST half: get a session, give it back                                  */
+/* -------------------------------------------------------------------------- */
+
+type Session = { sessionId: string; cdpEndpoint: string }
+
+async function createSession(apiKey: string): Promise<Session> {
+  const response = await fetch(`${SOLARI_API}/sessions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ stealth: false }),
+  })
+  if (!response.ok) {
+    throw new Error(
+      `create session failed (${response.status}): ${await response.text()}`,
+    )
+  }
+
+  const body = (await response.json()) as {
+    sessionId?: string
+    id?: string
+    wsEndpoint: string
+    cdpEndpoint?: string
+  }
+
+  // Two defensive reads, both earned. The identifier is `sessionId` on the
+  // wire but `id` on the SDKs' own `Session` type. And `cdpEndpoint` is
+  // optional — when the gateway omits it, the SDKs derive it from the
+  // WebSocket endpoint by swapping the path segment, so do the same.
+  const sessionId = body.sessionId ?? body.id
+  if (!sessionId || !body.wsEndpoint) {
+    throw new Error("create session returned no session id or wsEndpoint")
+  }
+
+  return {
+    sessionId,
+    cdpEndpoint: body.cdpEndpoint ?? body.wsEndpoint.replace("/ws/", "/cdp/"),
+  }
+}
+
+async function releaseSession(apiKey: string, sessionId: string) {
+  await fetch(`${SOLARI_API}/sessions/${encodeURIComponent(sessionId)}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${apiKey}` },
+  })
+}
+
+/* -------------------------------------------------------------------------- */
+/* The protocol half: a CDP client small enough to read                        */
+/* -------------------------------------------------------------------------- */
+
+type Cdp = {
+  send<T>(
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string,
+  ): Promise<T>
+  once(method: string): Promise<Record<string, unknown>>
+  close(): void
+}
+
+async function connect(endpoint: string): Promise<Cdp> {
+  // A Worker has no `new WebSocket(url)`. You upgrade an outbound `fetch`
+  // instead — and `fetch` will not take a ws:// URL, so swap the scheme and
+  // ask for the upgrade by header.
+  const response = await fetch(
+    endpoint.replace(/^ws:/, "http:").replace(/^wss:/, "https:"),
+    { headers: { Upgrade: "websocket" } },
+  )
+
+  const socket = response.webSocket
+  if (!socket) {
+    throw new Error(`CDP endpoint did not upgrade (HTTP ${response.status})`)
+  }
+  // `accept()` is what hands the socket to this Worker. Forget it and nothing
+  // errors: you just never receive a single message.
+  socket.accept()
+
+  let nextId = 1
+  const pending = new Map<
+    number,
+    { resolve: (value: any) => void; reject: (error: Error) => void }
+  >()
+  const waiting = new Map<string, (params: Record<string, unknown>) => void>()
+
+  socket.addEventListener("message", (event) => {
+    if (typeof event.data !== "string") return
+    const message = JSON.parse(event.data)
+
+    // One socket carries two kinds of frame: a reply, which has the `id` you
+    // sent, and an event, which has a `method`. Everything else about CDP
+    // follows from keeping those two apart.
+    if (typeof message.id === "number") {
+      const waiter = pending.get(message.id)
+      if (!waiter) return
+      pending.delete(message.id)
+      if (message.error) waiter.reject(new Error(`CDP: ${message.error.message}`))
+      else waiter.resolve(message.result ?? {})
+      return
+    }
+
+    if (typeof message.method === "string") {
+      waiting.get(message.method)?.(message.params ?? {})
+    }
+  })
+
+  const fail = (reason: string) => {
+    for (const [, waiter] of pending) waiter.reject(new Error(reason))
+    pending.clear()
+  }
+  socket.addEventListener("close", () => fail("CDP socket closed"))
+  socket.addEventListener("error", () => fail("CDP socket errored"))
+
+  return {
+    send(method, params = {}, sessionId) {
+      const id = nextId++
+      const frame = sessionId
+        ? { id, method, params, sessionId }
+        : { id, method, params }
+
+      return new Promise((resolve, reject) => {
+        // Always bound the wait. A CDP call that never gets an answer would
+        // otherwise hang the request until the Worker is killed, and the
+        // browser session would go with it — see the `finally` above.
+        const timer = setTimeout(() => {
+          pending.delete(id)
+          reject(new Error(`CDP ${method} timed out`))
+        }, 30_000)
+
+        pending.set(id, {
+          resolve: (value) => {
+            clearTimeout(timer)
+            resolve(value)
+          },
+          reject: (error) => {
+            clearTimeout(timer)
+            reject(error)
+          },
+        })
+        socket.send(JSON.stringify(frame))
+      })
+    },
+
+    once(method) {
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          waiting.delete(method)
+          reject(new Error(`timed out waiting for ${method}`))
+        }, 30_000)
+
+        waiting.set(method, (params) => {
+          clearTimeout(timer)
+          waiting.delete(method)
+          resolve(params)
+        })
+      })
+    },
+
+    close() {
+      fail("CDP connection closed by client")
+      try {
+        socket.close(1000, "done")
+      } catch {
+        // Already gone. Closing is best effort.
+      }
+    },
+  }
+}
+
+/** Run an expression in the page and get its value back. */
+async function evaluate<T>(
+  cdp: Cdp,
+  sessionId: string,
+  expression: string,
+): Promise<T> {
+  const result = await cdp.send<{
+    result?: { value?: unknown }
+    exceptionDetails?: { text?: string }
+  }>(
+    "Runtime.evaluate",
+    // `returnByValue` serialises the result instead of handing back a remote
+    // object reference you would then have to fetch separately.
+    { expression, returnByValue: true, awaitPromise: true },
+    sessionId,
+  )
+
+  // A page that throws comes back as a normal CDP reply, not an error frame.
+  // Without this check a broken page reads as `undefined`.
+  if (result.exceptionDetails) {
+    throw new Error(`page threw: ${result.exceptionDetails.text ?? "unknown"}`)
+  }
+  return result.result?.value as T
+}

--- a/examples/browser-workers-cdp-ts/package.json
+++ b/examples/browser-workers-cdp-ts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "solari-browser-workers-cdp-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260903.1",
+    "typescript": "^5.7.2",
+    "wrangler": "^4.20.0"
+  }
+}

--- a/examples/browser-workers-cdp-ts/tsconfig.json
+++ b/examples/browser-workers-cdp-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}

--- a/examples/browser-workers-cdp-ts/wrangler.jsonc
+++ b/examples/browser-workers-cdp-ts/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "solari-browser-workers-cdp",
+  "main": "index.ts",
+  "compatibility_date": "2026-09-01",
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
`@solarisdk/browser` bundles a Playwright fork that wants Node and raw TCP sockets, so it cannot run on Cloudflare Workers, Deno Deploy, or any other edge runtime. I hit this building on Workers, and the workaround I reached for first was a Node service beside the Worker whose only job was to hold the browser — an extra hop on every action, an extra deploy, and an extra thing to page someone about.

It turns out not to be necessary. Every session exposes a CDP endpoint, and any runtime that can hold an outbound WebSocket can drive the browser directly. Playwright is a convenience over that protocol, not a requirement of it, and the subset you need to open a page and read it is about sixty lines. I could not find this written down anywhere, so here it is as a runnable example.

### `examples/browser-workers-cdp-ts`

A Worker that launches a browser, opens a page, reads the title and `h1`, and releases the session. No runtime dependencies at all — the SDK is deliberately absent, which is the point.

```
GET /?url=https://example.com
{"url":"https://example.com/","title":"Example Domain","h1":"Example Domain","session":"..."}
```

Typechecks clean, bundles at 5.46 KiB under wrangler, and has been run against the live API.

### The five things that bite

Following the house style, each is commented at the line where it happens and listed in the example's README:

1. A Worker has no `new WebSocket(url)` — you upgrade an outbound `fetch` and must call `socket.accept()`, or you silently never receive a message.
2. A CDP connection is the browser, not a page. `Target.attachToTarget` with `flatten: true`, then carry the session id on every command meant for the page.
3. Domains are opt-in and silent until enabled, so a missing `Page.enable` reads as a hung navigation.
4. `Page.navigate` resolves when navigation *starts*, not when the page is ready — subscribe to `Page.loadEventFired` before navigating.
5. Closing the socket does not end the session; it bills on until its idle timeout.

Plus one about the payload rather than the protocol, which the example handles defensively: the create-session response carries the id as `sessionId` on the wire but as `id` on the SDKs' own `Session` type, and `cdpEndpoint` is optional — when absent I derive it from `wsEndpoint` by swapping `/ws/` for `/cdp/`, which is what the SDKs appear to do. Happy to simplify that if one of the two is actually guaranteed.

### Also

- One bullet added to the root README's gotchas, since "the TypeScript SDK cannot run on an edge runtime" is the kind of thing that costs an afternoon before you work out it is not your code.
- `.dev.vars` and `.wrangler/` added beside `.env` in the root `.gitignore` — Workers read local secrets from `.dev.vars`, not `.env`.