### PR TITLE
README: preview URLs carry a token, so append paths with new URL()

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Things that cost you an afternoon if you meet them cold:
   channel; the VM keeps running until its idle timeout.
 - **`timeoutMs` is a rolling idle window**, not a hard deadline — it resets on
   every use.
+- **The preview URL carries a `?pt_token=`, so build request URLs with `new URL()`.**
+  Appending a path to the string — `` `${url}/health` `` — puts the path inside the
+  *query*, and the gateway answers 401 for a request that looks perfectly correct.
+  Set `pathname` instead. The same token is minted into a cookie on first visit, so
+  a client sending its own `Cookie` header must merge rather than replace it, or it
+  signs itself out of the preview while still holding a valid token. Tokens expire
+  about an hour after minting; call `previewUrl()` again for a fresh one.
 
 ## Links
 

--- a/examples/sandbox-port-preview-ts/index.ts
+++ b/examples/sandbox-port-preview-ts/index.ts
@@ -28,6 +28,11 @@ try {
   const { url } = await sandbox.previewUrl(PORT)
   console.log("preview:", url)
 
+  // The URL carries a ?pt_token=… the gateway authenticates with, so reach for a
+  // path with `new URL()` rather than string concatenation:
+  //   const page = new URL(url); page.pathname = "/about"; fetch(page)
+  // `${url}/about` puts "/about" inside the query string and returns 401.
+
   // Prove it's really public: fetch it from *here*, outside the VM.
   for (let i = 0; i < 10; i++) {
     await new Promise((r) => setTimeout(r, 1000))


### PR DESCRIPTION
`previewUrl(port)` returns a URL carrying a `?pt_token=` query parameter. Building a request as `` `${url}/health` `` puts the path inside the *query string*, and the gateway answers 401 for a request that otherwise looks completely correct.

`sandbox-port-preview-ts` only ever fetches the root URL, so the example never meets this — which is exactly why it costs an afternoon the first time you point a client at a path.

There's a second half to it: the same token is minted into a cookie on first visit, so a client that sends its own `Cookie` header has to merge rather than replace it. Replacing signs you out of the *preview* while you're still holding a perfectly valid token, which surfaces as a 401 on a request that worked a moment earlier.

Adds a gotcha to the README list and a comment in the example itself, per the contributing note about putting surprising things where they bite.

Found while building a demo that serves a portal from a sandbox and drives it with a cloud browser.
