### PR TITLE
fix: update browser close examples for SDK 0.1.3

### DIFF
--- a/examples/browser-profiles-ts/index.ts
+++ b/examples/browser-profiles-ts/index.ts
@@ -39,6 +39,6 @@ try {
   console.log(`saved profile v${version} (${sizeBytes} bytes)`)
 } finally {
   await browser.close()
-  // Required, or the process never exits — see browser-quickstart-ts.
+  // Optional as of 0.1.3, and no longer needed to exit — see browser-quickstart-ts.
   await solari.close()
 }

--- a/examples/browser-quickstart-ts/README.md
+++ b/examples/browser-quickstart-ts/README.md
@@ -2,7 +2,7 @@
 
 Launch a cloud browser, open a page, read the title, close. The smallest complete Solari program.
 
-Note the `solari.close()` in the `finally` block — the client keeps a loopback proxy open for connection retries, and without closing it your script will print its output and then hang instead of exiting.
+Note the `solari.close()` in the `finally` block — the client keeps a loopback proxy open for connection retries. As of `@solarisdk/browser` 0.1.3 that listener is unref'd, so `browser.close()` alone is enough to exit and `solari.close()` is optional (it releases the client's pool immediately). Before 0.1.3 it was required, or your script would print its output and then hang instead of exiting.
 
 ## Run
 

--- a/examples/browser-quickstart-ts/index.ts
+++ b/examples/browser-quickstart-ts/index.ts
@@ -22,9 +22,11 @@ try {
   console.log("session:", browser.id)
 } finally {
   await browser.close()
-  // REQUIRED in Node, and easy to miss: the client keeps a loopback proxy
-  // server open for the connection-retry path, and that handle keeps the
-  // event loop alive. Skip this and your script prints its output and then
-  // hangs forever instead of exiting.
+  // Optional as of @solarisdk/browser 0.1.3: the client keeps a loopback proxy
+  // server open for the connection-retry path, but 0.1.3 unrefs that listener,
+  // so `browser.close()` alone is enough to exit. Calling `solari.close()` is
+  // still fine and releases the client's pool immediately. Before 0.1.3 it was
+  // required — skip it there and the script printed its output and then hung
+  // forever instead of exiting.
   await solari.close()
 }

--- a/examples/browser-stealth-proxy-ts/index.ts
+++ b/examples/browser-stealth-proxy-ts/index.ts
@@ -36,6 +36,6 @@ try {
   console.log("proxy  :", JSON.stringify(browser.proxy))
 } finally {
   await browser.close()
-  // Required, or the process never exits — see browser-quickstart-ts.
+  // Optional as of 0.1.3, and no longer needed to exit — see browser-quickstart-ts.
   await solari.close()
 }


### PR DESCRIPTION
The README was updated in 46709a1 to say browser.close() alone exits as of @solarisdk/browser 0.1.3, but the TypeScript examples still say solari.close() is required. This updates the four remaining places to match.

Verified on 0.1.3: a script calling browser.close() without solari.close() exits cleanly in ~3s.

The solari.close() calls are left in place — they're still valid and release the client's pool immediately. Comments only; no behavior change.