### PR TITLE
recording example: stop blaming recording=True on a poll timeout

### DIFF
--- a/examples/browser-session-recording-py/main.py
+++ b/examples/browser-session-recording-py/main.py
@@ -14,6 +14,11 @@ import os
 from solari_browser import Solari
 from solari_browser.errors import SolariError
 
+# The poll window, in one place: the message printed on timeout is derived from
+# these so it cannot drift from the loop that produced it.
+POLL_ATTEMPTS = 10
+POLL_INTERVAL_S = 3
+
 
 async def main() -> None:
     solari = Solari(api_key=os.environ["SOLARI_API_KEY"])
@@ -32,8 +37,8 @@ async def main() -> None:
     # The upload happens asynchronously AFTER the session is released, so the
     # first poll usually 404s even on a perfectly good recording. Retry before
     # concluding there is no replay.
-    for attempt in range(1, 11):
-        await asyncio.sleep(3)
+    for attempt in range(1, POLL_ATTEMPTS + 1):
+        await asyncio.sleep(POLL_INTERVAL_S)
         try:
             blob = await solari.sessions.download_replay(session_id)
         except SolariError as err:
@@ -49,7 +54,13 @@ async def main() -> None:
         print("first event:", events[0][:90], "...")
         return
 
-    print("no replay after ~30s — was the session created with recording=True?")
+    # Do NOT send the reader to check `recording=True` here: this script sets it
+    # at launch, so it can never be the cause. A 404 at this point means the
+    # upload had not appeared inside the window above, which is a different
+    # problem with a different fix.
+    print(f"no replay after ~{POLL_ATTEMPTS * POLL_INTERVAL_S}s.")
+    print("recording=True was set at launch, so this is not a missing recording.")
+    print(f"Retry the download later for session {session_id}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The timeout message asks the reader to check something the script itself guarantees.

```python
browser = await solari.launch(recording=True)                                  # line 21
print("no replay after ~30s — was the session created with recording=True?")   # line 52
```

`recording=True` is unconditional, so that question is already answered on every run. A user who hits the timeout is pointed at the one cause that's ruled out.

## Change

- New message: no longer blames `recording=True`, and prints the session id so the download can be retried.
- `POLL_ATTEMPTS` / `POLL_INTERVAL_S` constants, with the reported wait derived from them — `~30s` was previously hardcoded in prose and could drift from the loop.

Output text only; polling behaviour unchanged.

## Verified live

`@solarisdk/browser` 0.1.3, Python 3.11, fresh venv, real key. Final lines of three real runs:

```
before, timeout : no replay after ~30s — was the session created with recording=True?

after,  timeout : no replay after ~30s.
                  recording=True was set at launch, so this is not a missing recording.
                  Retry the download later for session ip-10-0-11-65:831dfc74-…

after,  success : replay: 2320 bytes, 6 rrweb events
```

## Why the message matters

Six runs: 4 timed out with no replay (~30s, ~30s, ~46s, still 404 at ~60s), 2 returned (~6s, ~8.2s). The loop sleeps before each download, so ~6s is the second poll. Three-way disagreement: the SDK doc comment says ~1-3s and no run matched it; the README says ~30s and two finished inside it; four exceeded both. So a persistent 404 is genuinely ambiguous — and the old text resolved it in the one direction the script rules out.

## Scope

Fixes the message, not the timing contract. Deliberately not proposing a replacement number: two failures exceeded 30s and one exceeded 60s, so I have no figure I could justify.

Unrelated: I have [#47](https://github.com/solari-sdk/solari-cookbook/pull/47) open on the stale `solari.close()` guidance.
