### PR TITLE
example: audit a frozen database before promoting its snapshot

### DIFF
--- a/examples/sandbox-audit-promote-py/README.md
+++ b/examples/sandbox-audit-promote-py/README.md
@@ -1,0 +1,42 @@
+# Audit a snapshot before promoting it
+
+A worker says `done` after debiting a buyer but forgetting to credit the seller.
+This example rejects that state. A complete transfer passes, becomes a reusable
+template through `promote_snapshot()`, and passes again after a fresh boot.
+
+```text
+fresh worker -----------> candidate snapshot -> host SQLite audit
+                                                      |
+                               reject <--- fail       pass
+                                                      |
+                                           promote exact snapshot
+                                                      |
+                                            boot and check bytes
+```
+
+```bash
+pip install -r requirements.txt
+export SOLARI_API_KEY=slr_live_...
+python main.py
+```
+
+Requires Python 3.11+ with SQLite deserialization support. Uses one cloud VM at
+a time and existing Solari credits. All created VMs, snapshots, and the promoted
+template have cleanup registered, including when a check fails. Cleanup errors
+are surfaced. The development run took 68 seconds; provisioning time varies.
+
+The worker is a deterministic simulation of an agent making a multi-step
+database change; this is a snapshot acceptance example, not an AI benchmark or
+a payment system. The database is closed before snapshotting. The live worker
+is then deliberately corrupted: only the frozen candidate should reach the
+auditor and template. SQLite checks run on the host after reading the database
+from a separate restored VM.
+
+For a real database transfer, use a database transaction. This example shows a
+boundary around fallible multi-step work where the caller cannot assume one
+transaction. It trusts the VM/files service and uses synthetic SQLite inputs;
+it does not certify a compromised runtime or roll back external side effects.
+
+The run prints its own source hash so an observed result can be tied to the
+code being reviewed. A passing demonstration covers these two constructed
+cases only.

--- a/examples/sandbox-audit-promote-py/main.py
+++ b/examples/sandbox-audit-promote-py/main.py
@@ -1,0 +1,114 @@
+"""Treat worker completion as a proposal; promote only an audited snapshot."""
+
+import asyncio
+import hashlib
+import os
+import sqlite3
+import time
+from contextlib import AsyncExitStack, asynccontextmanager, closing
+from pathlib import Path
+
+from solari_core import TemplateClient
+from solari_sandbox import SandboxClient
+
+DB = "/tmp/transfer.db"
+SEED = """
+CREATE TABLE accounts (name TEXT PRIMARY KEY, cents INTEGER NOT NULL);
+INSERT INTO accounts VALUES ('buyer', 10000), ('seller', 0);
+"""
+
+
+@asynccontextmanager
+async def machine(client, **source):
+    vm = await client.create(**source, timeout_ms=60_000)
+    async with AsyncExitStack() as cleanup:
+        cleanup.push_async_callback(client.kill, vm.sandboxId)
+        # Close the control socket while the VM is still alive, then kill it.
+        cleanup.push_async_callback(vm.close)
+        await vm.connect()
+        yield vm
+
+
+async def execute(vm, source):
+    result = await vm.commands.run("python3", args=["-c", source])
+    if result.exitCode != 0:
+        raise RuntimeError("Remote Python command failed")
+
+
+def audit(data):
+    # SQL runs on the host, outside the candidate VM. No worker verdict is used.
+    # These are synthetic, fallible-worker inputs, not hostile SQLite files.
+    with closing(sqlite3.connect(":memory:")) as db:
+        db.deserialize(data)
+        db.execute("PRAGMA query_only=ON")
+        rows = db.execute("SELECT name, cents FROM accounts ORDER BY name").fetchall()
+    return rows == [("buyer", 7500), ("seller", 2500)]
+
+
+async def main():
+    started = time.monotonic()
+    print("source SHA-256:", hashlib.sha256(Path(__file__).read_bytes()).hexdigest())
+    config = dict(
+        api_key=os.environ["SOLARI_API_KEY"], base_url="https://api.getsolari.com"
+    )
+    async with SandboxClient(**config) as client, AsyncExitStack() as cleanup:
+        templates = TemplateClient(**config)
+        cleanup.push_async_callback(templates.aclose)
+        for complete in (False, True):
+            label = "complete transfer" if complete else "half transfer"
+            async with AsyncExitStack() as case_cleanup:
+                async with machine(client, template="base") as worker:
+                    # Deterministic stand-in for an agent's multi-step work:
+                    # the faulty path commits the debit, omits the credit, and
+                    # still says done. No LLM or real payment is involved.
+                    credit = (
+                        "c.execute(\"UPDATE accounts SET cents=2500 WHERE name='seller'\")"
+                        if complete
+                        else "pass"
+                    )
+                    await execute(
+                        worker,
+                        f"import sqlite3\nc=sqlite3.connect({DB!r})\n"
+                        f"c.executescript({SEED!r})\n"
+                        "c.execute(\"UPDATE accounts SET cents=7500 WHERE name='buyer'\")\n"
+                        f"c.commit()\n{credit}\nc.commit()\nc.close()\nprint('done')",
+                    )
+                    candidate = await worker.snapshot("audit-promote-candidate")
+                    case_cleanup.push_async_callback(client.delete_snapshot, candidate)
+                    # Deliberately change the live worker after freezing it.
+                    # Auditing or promoting this live state would be wrong.
+                    await execute(
+                        worker,
+                        f"import sqlite3\nc=sqlite3.connect({DB!r})\n"
+                        "c.execute('UPDATE accounts SET cents=0')\nc.commit()\nc.close()",
+                    )
+
+                # Restore the exact candidate, copy its closed database, and
+                # inspect it on the host. The worker and its 'done' are gone.
+                async with machine(client, from_snapshot=candidate) as reader:
+                    frozen_bytes = await reader.files.read(DB)
+                accepted = audit(frozen_bytes)
+                print(f"{label}: worker=done audit={'PASS' if accepted else 'REJECT'}")
+                if accepted != complete:
+                    raise RuntimeError("Unexpected audit decision")
+                if not accepted:
+                    continue  # No promotion call exists on the rejection path.
+
+                template = await client.promote_snapshot(candidate, "audited-transfer")
+                template_id = template["templateId"]
+                case_cleanup.push_async_callback(templates.delete, template_id)
+                print("promoted audited snapshot:", candidate)
+                async with machine(client, template=template_id) as restored:
+                    restored_bytes = await restored.files.read(DB)
+                    if restored_bytes != frozen_bytes or not audit(restored_bytes):
+                        raise RuntimeError(
+                            "Promoted template did not preserve audited database"
+                        )
+                print("template boot: same database bytes, audit=PASS")
+    print(
+        f"PASS; VMs, snapshots, and template deleted ({time.monotonic() - started:.1f}s)"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandbox-audit-promote-py/requirements.txt
+++ b/examples/sandbox-audit-promote-py/requirements.txt
@@ -1,0 +1,1 @@
+solari-sandbox==0.2.1


### PR DESCRIPTION
A worker can report `done` after committing a debit and omitting the matching credit. This small example freezes that database, audits a copy restored from the candidate snapshot on the host, and calls the public `promote_snapshot()` only on pass. It then boots the template and checks the database is byte-for-byte identical to the audited copy.

This is the small version invited in #22. Thanks for the concrete feedback: this submission is three files (114 Python lines including whitespace), uses public SDK methods, and leaves the repository's opening description unchanged. The full Odoo project stays on its original branch; none of its historical validation claims are carried here.

### Read or run

`examples/sandbox-audit-promote-py/main.py` contains the entire flow. Install its requirements, set `SOLARI_API_KEY`, and run `python main.py` with Python 3.11+. It uses one VM at a time and registers cleanup for every VM, snapshot, and template it creates.

The agent is a deterministic stand-in, with one incomplete and one complete synthetic SQLite transfer. After taking each snapshot, the live worker's balances are deliberately changed to zero. A valid result therefore requires restoring and promoting the frozen candidate, not using the worker's later state. For a real database transfer, a database transaction remains the appropriate first choice.

### Verification

Fresh live results for the submitted `main.py` are recorded below. Its printed SHA-256 matches the Git blob:

`2292e29c1d08ab5097047755539e75d33af39ccca67ff163cc69b6ae0e145cf9`

Uninstrumented run on 2026-09-08, commit `ed637eb`:

```text
half transfer: worker=done audit=REJECT
complete transfer: worker=done audit=PASS
promoted audited snapshot: snap_dl9y54zwor32
template boot: same database bytes, audit=PASS
PASS; VMs, snapshots, and template deleted (68.1s)
```

The same source also passed a timed development run in 68.3 seconds. Provisioning time varies.

Local checks also rejected the initial balances, half-transfer, and extra-account case, and accepted the complete transfer. Ruff and diff checks passed.

A prior development revision hit a control-channel closure while reading a restored database; it aborted before promotion and completed snapshot cleanup. These are constructed demonstrations, not a reliability-rate claim or independent certification. The example trusts Solari's restored files and uses synthetic SQLite input; it does not claim protection against a compromised VM or rollback of external effects.
