### PR TITLE
Add prism: render one URL as every user class at once

### DIFF
--- a/applications/README.md
+++ b/applications/README.md
@@ -40,3 +40,4 @@ variable it reads and nothing else.
 | Application | Language | What it does |
 | --- | --- | --- |
 | [worldline](worldline) | Python | Snapshot-branch competing plans, verify their artifacts, and replay only the winner |
+| [prism](prism) | TypeScript | Render one URL as every user class at once and assert what each one actually saw |

--- a/applications/prism/.env.example
+++ b/applications/prism/.env.example
@@ -1,0 +1,4 @@
+# Only needed for --backend solari. --backend local needs no credentials.
+SOLARI_API_KEY=slr_live_...
+# Port for `npm run site` (standalone demo site). Default 8788.
+PORT=8788

--- a/applications/prism/.gitignore
+++ b/applications/prism/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.DS_Store

--- a/applications/prism/README.md
+++ b/applications/prism/README.md
@@ -1,0 +1,164 @@
+# Prism
+
+One URL, every user class at once.
+
+A web app shows different things to different people: signed out, free, paid,
+admin, consented, not consented. Getting that wrong is expensive in two
+directions — a free account that can reach a paid feature is revenue walking out
+the door, and a visitor who refused cookies but still loads your tracker is a
+regulatory problem. Almost nobody tests it, because testing it means holding
+several sets of real credentials and driving several authenticated browsers at
+the same time.
+
+Prism renders one URL as every user class simultaneously and asserts what each
+one **actually saw**.
+
+## Watch it
+
+Needs no credentials. The demo site ships two deliberate bugs.
+
+```bash
+npm install && npx playwright install chromium
+npm run demo
+```
+
+```
+| user class | verdict | what was wrong | time |
+|---|---|---|---|
+| anon | FAIL | LEAKED tracker | 351ms |
+| free | FAIL | LEAKED export | 350ms |
+| paid | pass | as expected | 345ms |
+| admin | pass | as expected | 351ms |
+| eu-consent-rejected | FAIL | LEAKED tracker, LEAKED export | 347ms |
+| anon-consent-accepted | pass | as expected | 350ms |
+```
+
+`free` reaching the Pro export button is the revenue leak. The tracker firing
+for anyone who has not consented -- both the fresh visitor and the one who
+explicitly refused -- is the compliance breach. Two bugs, but they surface on
+three identities, and `eu-consent-rejected` reports both because it is also a
+free account. The run exits 0: finding them is the point. `npm run demo --
+--fix` serves the corrected app and all six pass.
+
+Two rules the class list has to obey, both learned by breaking them. No two
+classes may share an identity, or the same page gets judged twice by different
+standards and one verdict is wrong by construction. And every class must reject
+everything it should never see, not just its headline concern -- an earlier
+version let `anon` pass with the tracker on screen, because tracking was
+"someone else's row".
+
+## How it decides
+
+Every verdict comes from `data-testid` attributes read off a live page after a
+real HTTP navigation. Nothing asserts that a profile attached or that a cookie
+was set — those can all be true while the user still sees the wrong page. Each
+class declares what it must see and must not see, and why:
+
+```ts
+{
+  name: "free",
+  mustSee: ["heading", "quota"],
+  mustNotSee: ["export", "admin"],
+  because: "a free account must not reach paid-only export -- this is revenue leak",
+}
+```
+
+The `because` line is printed on failure, so a red run explains itself without
+anyone reading the source.
+
+## The Solari part
+
+The honest claim is not "many browsers at once" — a laptop can run twenty
+Playwright contexts with twenty `storageState` objects. It is **where the
+session lives**.
+
+A Solari profile is server-side. A human populates it once in the console's live
+browser, clearing 2FA and a captcha by hand. Every run after that needs only
+`SOLARI_API_KEY`. Local Playwright cannot do this: the credential has to exist
+somewhere you control — a secret store, a committed cookie jar, a file on the
+runner. Prism's `check` phase never holds one.
+
+The demo seeds profile state directly so it reproduces with no accounts. That
+shortcut is opt-in and nothing else turns it on: against a real target Prism
+refuses to run unless the profile already exists, rather than overwriting a
+session a human enrolled by hand.
+
+```
+no Solari profile named "prism-paid". Enrol it once in the console's live
+browser (console.getsolari.com), or pass --seed to have Prism write demo
+cookies into it. Prism will not create or overwrite a profile you did not
+ask it to.
+```
+
+## Running on Solari
+
+```bash
+export SOLARI_API_KEY=slr_live_...
+npm run check -- --backend solari
+```
+
+A cloud browser cannot reach `127.0.0.1`, so with no `--url` Prism serves the
+demo site from a Solari **sandbox** and points the browsers at its public
+preview URL — sandbox and browsers on one key. Point `--url` at a real
+deployment to check your own app.
+
+Verified live on 2026-09-08 (Starter): six cloud browsers, six server-side
+profiles, sandbox-hosted site, guest Node v18.20.4. Same verdicts as the local
+run on all six classes, ~8.1s per class. The runs are committed in
+[`proof/`](proof) — `local.json` and `solari.json`, generated with `--proof`.
+
+Two traps that cost time, in case they save you some:
+
+- `previewUrl()` returns a URL whose credential is a `pt_token` **query
+  parameter**. Fetching the same origin without it is `401 invalid preview
+  token`, and the token is rejected as an `Authorization` header, an
+  `x-solari-token` header, or a cookie. Rebuilding the URL — even
+  `new URL("/", url)` — locks you out.
+- The base sandbox image runs Node 18 with no build step, so the site uploaded
+  to it is the same plain `demo-site/site.js` the local run uses. One file, so
+  the cloud cannot quietly serve a different app than the one you checked.
+
+## The fleet
+
+Starter documents 20 concurrent browsers. Measured on 2026-09-08, the API
+accepts 18 and refuses the 19th with
+`429 {"code":"ConcurrencyLimitExceeded","cap":20}` — the error states a cap it
+does not honour. A released slot is reusable in about 300ms.
+
+So `runFleet` starts below the published number and **shrinks on backpressure**
+rather than trusting it. Two properties have to hold, and an earlier hand-rolled
+scheduler broke both: never more than the current limit running (a retry that
+re-enters without re-acquiring goes straight back over the cap that just
+rejected it), and never resolve while a probe is in flight (resolving early lets
+a retry open a cloud session *after* the backend closed — leaking the billable
+slot the pool exists to protect). A semaphore plus `Promise.all` gives both by
+construction.
+
+## What this does not do
+
+- **The demo site is ours.** This proves the mechanism, not that a real paywall
+  was defeated. Pointing `--url` at a real app is the one config change.
+- **No anti-bot claim.** Stealth returns
+  `503 {"error":"No stealth pool available","fleet":"empty"}`, and proxy
+  requires stealth, so neither was exercised.
+- **No replay evidence.** `recording: true` produced no replay on `kind: "fast"`
+  in 29 sessions, so Prism's evidence is its own `proof/` files, not a Solari
+  replay.
+- **The tracker check is DOM presence,** not a network assertion. It catches a
+  tracker tag in the markup; a tracker injected later by script, or one that
+  fires without leaving a tagged element, would need a request-level check.
+  Solari can do that over raw CDP -- see `eu-consent-evidence-ts` -- and Prism
+  deliberately does not, because a DOM check is honest about being one.
+- **~18 concurrent, not 20.**
+
+## Reproducing
+
+```bash
+npm install
+npx playwright install chromium
+npm test                    # 21 tests, no credentials
+npm run demo                # the two planted bugs, exit 0
+npm run demo -- --fix       # all six pass
+```
+
+MIT.

--- a/applications/prism/demo-site/app.ts
+++ b/applications/prism/demo-site/app.ts
@@ -1,0 +1,12 @@
+/**
+ * Typed surface over the demo app.
+ *
+ * The implementation lives in `site.js` because the Solari sandbox that hosts
+ * this site for `--backend solari` runs Node 18 with no build step, and the
+ * cloud must serve the same bytes the local run checked. This file exists only
+ * so the TypeScript side gets real types.
+ */
+export type Tier = "anon" | "free" | "paid" | "admin"
+export type Bugs = { leakExportToFree: boolean; trackerBeforeConsent: boolean }
+
+export { DEFAULT_BUGS, NO_BUGS, render, makeHandler, parseCookies } from "./site.js"

--- a/applications/prism/demo-site/serve.ts
+++ b/applications/prism/demo-site/serve.ts
@@ -1,0 +1,34 @@
+/**
+ * Serves the demo app on a real port over real HTTP, so the browser performs an
+ * actual navigation. Never `setContent()` of an inline string: a cloud browser
+ * that only renders strings is not doing anything a local one would not.
+ *
+ * The handler itself comes from `site.js`, which is also what the sandbox runs.
+ */
+import { createServer, type Server } from "node:http"
+import { DEFAULT_BUGS, makeHandler, type Bugs } from "./app.js"
+
+export type DemoSite = { url: string; close: () => Promise<void> }
+
+export async function serve(port = 0, bugs: Bugs = DEFAULT_BUGS): Promise<DemoSite> {
+  const server: Server = createServer(makeHandler(bugs))
+  await new Promise<void>((r) => server.listen(port, "127.0.0.1", r))
+  const addr = server.address()
+  if (typeof addr === "string" || addr === null) throw new Error("no port")
+  return {
+    url: `http://127.0.0.1:${addr.port}/`,
+    close: () =>
+      new Promise((r) => {
+        // Browsers hold the connection open with keep-alive, and `close()`
+        // waits for existing sockets to drain -- so without this the process
+        // prints its report and then hangs forever.
+        server.closeAllConnections()
+        server.close(() => r())
+      }),
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const site = await serve(Number(process.env.PORT ?? 8788))
+  console.log(`demo site on ${site.url}`)
+}

--- a/applications/prism/demo-site/server.js
+++ b/applications/prism/demo-site/server.js
@@ -1,0 +1,13 @@
+/**
+ * Standalone entry point. This is what runs inside the Solari sandbox:
+ *   node server.js <port> [--fix]
+ * No dependencies, no build, Node 18 compatible.
+ */
+import { createServer } from "node:http"
+import { DEFAULT_BUGS, NO_BUGS, makeHandler } from "./site.js"
+
+const port = Number(process.argv[2] || process.env.PORT || 8788)
+const bugs = process.argv.includes("--fix") ? NO_BUGS : DEFAULT_BUGS
+createServer(makeHandler(bugs)).listen(port, "0.0.0.0", () => {
+  console.log(`demo site on :${port} (${bugs.leakExportToFree ? "with planted bugs" : "bugs fixed"})`)
+})

--- a/applications/prism/demo-site/site.js
+++ b/applications/prism/demo-site/site.js
@@ -1,0 +1,87 @@
+/**
+ * The demo app: a small entitlement-gated page, and the request handler for it.
+ *
+ * Plain JavaScript on purpose. This exact file is what runs BOTH locally and
+ * inside the Solari sandbox that hosts it for `--backend solari`. The base
+ * sandbox image ships Node 18 and has no build step, so anything TypeScript
+ * here would have to be compiled or duplicated -- and a second copy is how the
+ * cloud quietly starts serving a different app than the one the local run
+ * checked. One file, no translation.
+ *
+ * It reads a `tier` cookie and a `consent` cookie and renders different markup
+ * for each combination, the same shape as a real product with a paywall and a
+ * consent banner. Two combinations are deliberately WRONG, because a checker
+ * that only ever sees correct pages proves nothing:
+ *
+ *   - `free` leaks the paid-only export button   (revenue leak)
+ *   - consent=rejected still emits the tracker    (compliance breach)
+ *
+ * Both are switchable, so the same site demonstrates a failing run and a clean
+ * one.
+ */
+
+/** @typedef {"anon" | "free" | "paid" | "admin"} Tier */
+/** @typedef {{ leakExportToFree: boolean, trackerBeforeConsent: boolean }} Bugs */
+
+/** @type {Bugs} */
+export const DEFAULT_BUGS = { leakExportToFree: true, trackerBeforeConsent: true }
+
+/** @type {Bugs} */
+export const NO_BUGS = { leakExportToFree: false, trackerBeforeConsent: false }
+
+/** @param {string} s */
+const esc = (s) => s.replace(/[<>&]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" })[c])
+
+/**
+ * @param {Tier} tier
+ * @param {string} consent
+ * @param {Bugs} bugs
+ * @returns {string}
+ */
+export function render(tier, consent, bugs) {
+  const paid = tier === "paid" || tier === "admin"
+  // The leak: `free` is not a paying tier, but the button renders anyway.
+  const showExport = paid || (bugs.leakExportToFree && tier === "free")
+  const showAdmin = tier === "admin"
+  const consented = consent === "accepted"
+  // The breach: the tracker should require consent, and does not.
+  const tracker = consented || bugs.trackerBeforeConsent
+
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Ledger — ${esc(tier)}</title>
+${tracker ? `<script data-testid="tracker" src="/t.js"></script>` : ""}
+</head><body>
+<h1 data-testid="heading">Ledger</h1>
+<p data-testid="tier">Signed in as: ${esc(tier)}</p>
+${consented ? "" : `<div data-testid="consent-banner">We use cookies. <button>Accept</button></div>`}
+${tier === "anon" ? `<a data-testid="signin" href="/signin">Sign in</a>` : ""}
+${showExport ? `<button data-testid="export">Export all invoices (Pro)</button>` : ""}
+${showAdmin ? `<a data-testid="admin" href="/admin">Admin console</a>` : ""}
+<p data-testid="quota">Invoices this month: ${paid ? "unlimited" : "3 of 5"}</p>
+</body></html>`
+}
+
+/** @param {string | undefined} header */
+export function parseCookies(header) {
+  return Object.fromEntries(
+    String(header || "").split(";").map((p) => p.trim().split("=")).filter((p) => p.length === 2),
+  )
+}
+
+/**
+ * @param {Bugs} bugs
+ * @returns {(req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => void}
+ */
+export function makeHandler(bugs) {
+  return (req, res) => {
+    if (req.url === "/t.js") {
+      res.writeHead(200, { "content-type": "application/javascript" })
+      return res.end("//tracker\n")
+    }
+    if (req.url === "/favicon.ico") { res.writeHead(204); return res.end() }
+    const c = parseCookies(req.headers.cookie)
+    const tier = ["anon", "free", "paid", "admin"].includes(c.tier) ? c.tier : "anon"
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+    res.end(render(/** @type {Tier} */ (tier), c.consent || "", bugs))
+  }
+}

--- a/applications/prism/package.json
+++ b/applications/prism/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "prism",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "demo": "tsx src/cli.ts check --backend local",
+    "check": "tsx src/cli.ts check",
+    "site": "tsx demo-site/serve.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@solarisdk/browser": "^0.1.3",
+    "@solarisdk/sdk": "^0.1.3",
+    "playwright": "^1.56.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.4.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.11"
+  }
+}

--- a/applications/prism/proof/README.md
+++ b/applications/prism/proof/README.md
@@ -1,0 +1,22 @@
+# Evidence
+
+Two runs of the same six checks against the same app, one on local Chromium and
+one on Solari cloud browsers. Generated with `--proof`, not written by hand:
+
+```bash
+npm run demo -- --proof proof/local.json
+SOLARI_API_KEY=slr_live_... npm run check -- --backend solari --proof proof/solari.json
+```
+
+`local.json` — local Playwright, demo site on `127.0.0.1`.
+`solari.json` — six Solari browsers with six server-side profiles, demo site
+hosted in a Solari sandbox on its public preview URL (guest Node v18.20.4),
+2026-09-08, Starter plan.
+
+Both agree on all six classes: `anon` leaks `tracker`, `free` leaks `export`,
+`eu-consent-rejected` leaks both, and the other three pass. That agreement is the point — the sandbox
+runs the same `demo-site/site.js` the local run serves, so a divergence would
+mean the cloud was checking a different app.
+
+`target` records only the origin. The preview URL's `pt_token` query parameter
+is a live credential and is deliberately not committed.

--- a/applications/prism/proof/local.json
+++ b/applications/prism/proof/local.json
@@ -1,0 +1,109 @@
+{
+  "backend": "local",
+  "classes": 6,
+  "bugsPlanted": true,
+  "target": "http://127.0.0.1:61632",
+  "backpressureEvents": [],
+  "results": [
+    {
+      "name": "anon",
+      "ok": false,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "consent-banner",
+        "signin",
+        "quota"
+      ],
+      "findings": [
+        {
+          "kind": "leaked",
+          "testid": "tracker"
+        }
+      ],
+      "ms": 655
+    },
+    {
+      "name": "free",
+      "ok": false,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "export",
+        "quota"
+      ],
+      "findings": [
+        {
+          "kind": "leaked",
+          "testid": "export"
+        }
+      ],
+      "ms": 649
+    },
+    {
+      "name": "paid",
+      "ok": true,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "export",
+        "quota"
+      ],
+      "findings": [],
+      "ms": 645
+    },
+    {
+      "name": "admin",
+      "ok": true,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "export",
+        "admin",
+        "quota"
+      ],
+      "findings": [],
+      "ms": 649
+    },
+    {
+      "name": "eu-consent-rejected",
+      "ok": false,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "consent-banner",
+        "export",
+        "quota"
+      ],
+      "findings": [
+        {
+          "kind": "leaked",
+          "testid": "tracker"
+        },
+        {
+          "kind": "leaked",
+          "testid": "export"
+        }
+      ],
+      "ms": 650
+    },
+    {
+      "name": "anon-consent-accepted",
+      "ok": true,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "signin",
+        "quota"
+      ],
+      "findings": [],
+      "ms": 650
+    }
+  ]
+}

--- a/applications/prism/proof/solari.json
+++ b/applications/prism/proof/solari.json
@@ -1,0 +1,109 @@
+{
+  "backend": "solari",
+  "classes": 6,
+  "bugsPlanted": true,
+  "target": "https://87b8377dcd7767f473a7-3000.preview.getsolari.com",
+  "backpressureEvents": [],
+  "results": [
+    {
+      "name": "anon",
+      "ok": false,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "consent-banner",
+        "signin",
+        "quota"
+      ],
+      "findings": [
+        {
+          "kind": "leaked",
+          "testid": "tracker"
+        }
+      ],
+      "ms": 8942
+    },
+    {
+      "name": "free",
+      "ok": false,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "export",
+        "quota"
+      ],
+      "findings": [
+        {
+          "kind": "leaked",
+          "testid": "export"
+        }
+      ],
+      "ms": 7357
+    },
+    {
+      "name": "paid",
+      "ok": true,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "export",
+        "quota"
+      ],
+      "findings": [],
+      "ms": 8914
+    },
+    {
+      "name": "admin",
+      "ok": true,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "export",
+        "admin",
+        "quota"
+      ],
+      "findings": [],
+      "ms": 7995
+    },
+    {
+      "name": "eu-consent-rejected",
+      "ok": false,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "consent-banner",
+        "export",
+        "quota"
+      ],
+      "findings": [
+        {
+          "kind": "leaked",
+          "testid": "tracker"
+        },
+        {
+          "kind": "leaked",
+          "testid": "export"
+        }
+      ],
+      "ms": 8899
+    },
+    {
+      "name": "anon-consent-accepted",
+      "ok": true,
+      "saw": [
+        "tracker",
+        "heading",
+        "tier",
+        "signin",
+        "quota"
+      ],
+      "findings": [],
+      "ms": 6720
+    }
+  ]
+}

--- a/applications/prism/src/backend.ts
+++ b/applications/prism/src/backend.ts
@@ -1,0 +1,35 @@
+/**
+ * Two places a browser can run. The check logic does not know which it got.
+ *
+ * `local`  -- Playwright on this machine. Needs no key, so the whole demo runs
+ *             offline. It is also the control: if local and Solari disagree,
+ *             that is a finding.
+ * `solari` -- a cloud browser attached to a server-side profile. The point is
+ *             not that it is a browser; it is that the SESSION lives on the
+ *             server, so a CI run needs only SOLARI_API_KEY and never holds a
+ *             credential. A laptop cannot do that: local Playwright needs the
+ *             cookie jar to exist somewhere you control.
+ */
+export type PageProbe = {
+  /** testids present on the rendered page. */
+  testids: string[]
+  title: string
+  url: string
+}
+
+export type Backend = {
+  name: string
+  /**
+   * Does this error mean "the account is at its cap", as opposed to a real
+   * failure? Only the backend knows -- `check()` must not import a specific
+   * backend to find out, or it stops being backend-agnostic.
+   */
+  isBackpressure?: (err: unknown) => boolean
+  /** Render `url` as this identity and report what was actually on the page. */
+  probe(url: string, cookies: { name: string; value: string }[], label: string): Promise<PageProbe>
+  close(): Promise<void>
+}
+
+/** Read testids off a live page. Never trust a claim; read the DOM. */
+export const EXTRACT = () =>
+  Array.from(document.querySelectorAll("[data-testid]")).map((e) => e.getAttribute("data-testid")!)

--- a/applications/prism/src/backends-local.ts
+++ b/applications/prism/src/backends-local.ts
@@ -1,0 +1,36 @@
+/** Playwright on this machine. No key, no network beyond the demo site. */
+import { chromium, type Browser } from "playwright"
+import { EXTRACT, type Backend, type PageProbe } from "./backend.js"
+
+export async function localBackend(): Promise<Backend> {
+  // Memoize the PROMISE, not the browser. `browser ??= await launch()` is not
+  // atomic across the await: every concurrent probe would see null and launch
+  // its own Chromium, and all but the last would leak -- the process then
+  // never exits because orphaned children hold the event loop open.
+  let launching: Promise<Browser> | null = null
+  const get = () => (launching ??= chromium.launch())
+  return {
+    name: "local",
+    async probe(url, cookies): Promise<PageProbe> {
+      const b = await get()
+      const origin = new URL(url).origin
+      const ctx = await b.newContext()
+      try {
+        await ctx.addCookies(cookies.map((c) => ({ ...c, url: origin })))
+        const page = await ctx.newPage()
+        await page.goto(url, { waitUntil: "load" })
+        return { testids: await page.evaluate(EXTRACT), title: await page.title(), url: page.url() }
+      } finally {
+        // Without the finally, a probe that throws leaks its context: the
+        // browser stays alive holding it and the process never exits.
+        await ctx.close()
+      }
+    },
+    async close() {
+      // Never re-throw here. close() runs in the caller's `finally`, so a
+      // rejection would mask the real error and skip the rest of the cleanup.
+      if (!launching) return
+      await launching.then((b) => b.close()).catch(() => {})
+    },
+  }
+}

--- a/applications/prism/src/backends-solari.ts
+++ b/applications/prism/src/backends-solari.ts
@@ -1,0 +1,83 @@
+/**
+ * Solari cloud browsers, one server-side profile per user class.
+ *
+ * Three traps, all of them why the profiles example has been fixed twice:
+ *   1. `profileId` does NOT seed the browser. The state arrives on
+ *      `session.storageState` and must be handed to `newContext`; a page from
+ *      `browser.newPage()` starts anonymous.
+ *   2. State is discarded on release unless `profiles.save()` is called.
+ *   3. A context you build yourself does not inherit the pool's timezone pin,
+ *      so `timezoneId` has to be forwarded or Intl disagrees with the egress IP.
+ */
+import { Solari, SolariError } from "@solarisdk/browser"
+import { EXTRACT, type Backend, type PageProbe } from "./backend.js"
+
+export type SolariOpts = {
+  apiKey: string
+  profilePrefix?: string
+  /**
+   * Overwrite each profile's stored state with the class's cookies before
+   * every probe. This is how the bundled demo runs without anyone owning an
+   * account on the target app, and it MUST stay opt-in: against a real target
+   * the profiles hold sessions a human enrolled by hand in the console, and
+   * seeding would destroy them -- the exact thing this application claims you
+   * never have to do.
+   */
+  seed?: boolean
+}
+
+export async function solariBackend(opts: SolariOpts): Promise<Backend> {
+  const solari = new Solari({ apiKey: opts.apiKey })
+  const prefix = opts.profilePrefix ?? "prism"
+  const seed = opts.seed === true
+
+  return {
+    name: "solari",
+    isBackpressure,
+    async probe(url, cookies, label): Promise<PageProbe> {
+      const name = `${prefix}-${label}`
+      const existing = (await solari.profiles.list()).find((p) => p.name === name)
+
+      if (!seed && !existing) {
+        throw new Error(
+          `no Solari profile named "${name}". Enrol it once in the console's live ` +
+            `browser (console.getsolari.com), or pass --seed to have Prism write ` +
+            `demo cookies into it. Prism will not create or overwrite a profile ` +
+            `you did not ask it to.`,
+        )
+      }
+
+      const profile = existing ?? (await solari.profiles.create({ name }))
+
+      if (seed) {
+        const origin = new URL(url).origin
+        await solari.profiles.save(profile.id, {
+          cookies: cookies.map((c) => ({ ...c, domain: new URL(origin).hostname, path: "/" })),
+        })
+      }
+
+      const browser = await solari.launch({ profileId: profile.id })
+      try {
+        const storageState = browser.session.storageState as
+          | NonNullable<Parameters<typeof browser.newContext>[0]>["storageState"]
+          | undefined
+        const ctx = await browser.newContext({ storageState, timezoneId: browser.proxy?.timezoneId })
+        const page = await ctx.newPage()
+        await page.goto(url, { waitUntil: "load" })
+        return { testids: await page.evaluate(EXTRACT), title: await page.title(), url: page.url() }
+      } finally {
+        await browser.close()
+      }
+    },
+    async close() { await solari.close() },
+  }
+}
+
+/**
+ * True when the API refused because the account is at its concurrency cap.
+ * Measured: `429 {"code":"ConcurrencyLimitExceeded","cap":20}` -- retryable
+ * once a slot frees, unlike every other 4xx.
+ */
+export function isBackpressure(err: unknown): boolean {
+  return err instanceof SolariError && err.status === 429
+}

--- a/applications/prism/src/check.ts
+++ b/applications/prism/src/check.ts
@@ -1,0 +1,56 @@
+/**
+ * The check itself: render one URL as every user class, then assert what each
+ * one ACTUALLY saw.
+ *
+ * Nothing here trusts that a profile attached, or that a cookie was set. Every
+ * verdict comes from testids read off a live page -- the same discipline as
+ * clicking a repaired element and confirming the page changed, rather than
+ * believing a claim about it.
+ */
+import type { Backend } from "./backend.js"
+import { CLASSES, type UserClass } from "./classes.js"
+import { runFleet } from "./fleet.js"
+
+export type Finding = { kind: "missing" | "leaked"; testid: string }
+export type ClassResult = {
+  name: string
+  because: string
+  ok: boolean
+  saw: string[]
+  findings: Finding[]
+  error?: string
+  ms: number
+}
+
+export function judge(cls: UserClass, saw: string[]): Finding[] {
+  const set = new Set(saw)
+  return [
+    ...cls.mustSee.filter((t) => !set.has(t)).map((t): Finding => ({ kind: "missing", testid: t })),
+    ...cls.mustNotSee.filter((t) => set.has(t)).map((t): Finding => ({ kind: "leaked", testid: t })),
+  ]
+}
+
+export async function check(
+  backend: Backend,
+  url: string,
+  classes: UserClass[] = CLASSES,
+  onEvent?: (e: { type: string; concurrency: number }) => void,
+): Promise<ClassResult[]> {
+  const results = await runFleet(
+    classes.map((cls) => async (): Promise<ClassResult> => {
+      const t0 = Date.now()
+      const probe = await backend.probe(url, cls.cookies, cls.name)
+      const findings = judge(cls, probe.testids)
+      return {
+        name: cls.name, because: cls.because, ok: findings.length === 0,
+        saw: probe.testids, findings, ms: Date.now() - t0,
+      }
+    }),
+    { isBackpressure: backend.isBackpressure ?? (() => false), onEvent },
+  )
+
+  return results.map((r, i) => r.value ?? {
+    name: classes[i]!.name, because: classes[i]!.because, ok: false, saw: [],
+    findings: [], error: String(r.error).slice(0, 200), ms: 0,
+  })
+}

--- a/applications/prism/src/classes.ts
+++ b/applications/prism/src/classes.ts
@@ -1,0 +1,81 @@
+/**
+ * The user classes to check, and what each must and must not see.
+ *
+ * Expectations are stated as testids that must be present or absent on the
+ * rendered page. That is deliberate: a check that asserts "the profile was
+ * attached" proves nothing about what the user actually got. Prism only ever
+ * asserts things read back off a live page.
+ *
+ * Two rules this list has to obey, both learned by getting them wrong:
+ *
+ *   1. No two classes may carry the same identity. If they do, the same page
+ *      is judged twice by different standards, and one of the verdicts is
+ *      wrong by construction.
+ *   2. Every class must reject everything it should never see -- not just the
+ *      one thing it is "about". A class that only lists its headline concern
+ *      passes while a different bug is on screen in front of it.
+ */
+export type UserClass = {
+  name: string
+  /** Cookies that define this identity. In production these come from a real
+   *  login performed once in Solari's console; here they are seeded so the
+   *  demo reproduces with no accounts. */
+  cookies: { name: string; value: string }[]
+  mustSee: string[]
+  mustNotSee: string[]
+  /** Why this class exists, printed in the report so a failure explains itself. */
+  because: string
+}
+
+export const CLASSES: UserClass[] = [
+  {
+    name: "anon",
+    // No cookies at all: a genuinely fresh visitor, not one carrying a
+    // tier=anon marker that a real signed-out user would never have.
+    cookies: [],
+    mustSee: ["heading", "signin", "consent-banner", "quota"],
+    // Nothing has been consented to yet, so a tracker here is as much a breach
+    // as an explicit refusal. Listing it is what makes this class able to fail.
+    mustNotSee: ["export", "admin", "tracker"],
+    because: "a fresh visitor has consented to nothing and has bought nothing",
+  },
+  {
+    name: "free",
+    cookies: [{ name: "tier", value: "free" }, { name: "consent", value: "accepted" }],
+    mustSee: ["heading", "quota", "tier"],
+    mustNotSee: ["export", "admin", "signin"],
+    because: "a free account must not reach paid-only export -- this is revenue leak",
+  },
+  {
+    name: "paid",
+    cookies: [{ name: "tier", value: "paid" }, { name: "consent", value: "accepted" }],
+    mustSee: ["heading", "export", "quota"],
+    mustNotSee: ["admin", "signin", "consent-banner"],
+    because: "a paying account must get what it pays for, and no admin surface",
+  },
+  {
+    name: "admin",
+    cookies: [{ name: "tier", value: "admin" }, { name: "consent", value: "accepted" }],
+    mustSee: ["heading", "export", "admin", "quota"],
+    mustNotSee: ["signin", "consent-banner"],
+    because: "an admin gets everything, but must still not look signed out",
+  },
+  {
+    name: "eu-consent-rejected",
+    cookies: [{ name: "tier", value: "free" }, { name: "consent", value: "rejected" }],
+    mustSee: ["heading", "consent-banner"],
+    // Both, not just the tracker: this identity is also a free account, so the
+    // paid export must be absent here for exactly the reason it is for `free`.
+    mustNotSee: ["tracker", "export", "admin"],
+    because: "a visitor who refused consent must not be tracked, and is still not a paying account",
+  },
+  {
+    name: "anon-consent-accepted",
+    // Distinct from every other row: signed out, but has accepted. Reusing
+    // free's cookies here would judge one identical page by two standards.
+    cookies: [{ name: "consent", value: "accepted" }],
+    mustSee: ["heading", "signin", "tracker", "quota"],
+    mustNotSee: ["consent-banner", "export", "admin"],
+    because: "consent means the tracker is allowed and the banner must stop asking",
+  },
+]

--- a/applications/prism/src/cli.ts
+++ b/applications/prism/src/cli.ts
@@ -1,0 +1,166 @@
+/**
+ * prism check [--backend local|solari] [--url URL] [--fix]
+ *
+ * With no --url, Prism starts its own demo site, which ships two deliberate
+ * bugs: `free` sees the paid export button, and a visitor who refused consent
+ * still gets the tracker. `--fix` serves the corrected app instead, so you can
+ * see the same run go green.
+ *
+ * --backend local needs no credentials at all.
+ */
+import { serve } from "../demo-site/serve.js"
+import { hostInSandbox } from "./host.js"
+import { localBackend } from "./backends-local.js"
+import { solariBackend } from "./backends-solari.js"
+import { check } from "./check.js"
+import { explain, table } from "./report.js"
+import { CLASSES } from "./classes.js"
+import { writeFileSync, mkdirSync } from "node:fs"
+import type { Backend } from "./backend.js"
+
+/**
+ * A cloud browser cannot reach this machine. Match on the parsed hostname, not
+ * a substring: "https://localhost-tools.example.com" is public and must be
+ * allowed, while 0.0.0.0 and [::1] are not and a substring test misses both.
+ */
+function isLoopback(u: string): boolean {
+  let host: string
+  try { host = new URL(u).hostname.toLowerCase() } catch { return false }
+  const bare = host.replace(/^\[|\]$/g, "")
+  return bare === "localhost" || bare.endsWith(".localhost") ||
+    bare === "0.0.0.0" || bare === "::1" || bare === "::" ||
+    /^127\./.test(bare)
+}
+
+const argv = process.argv.slice(2)
+const cmd = argv[0] ?? "check"
+const flag = (n: string, d?: string) => {
+  const i = argv.indexOf(`--${n}`)
+  return i >= 0 ? (argv[i + 1] ?? "") : d
+}
+const has = (n: string) => argv.includes(`--${n}`)
+const backendNameEarly = () => flag("backend", "local")!
+
+if (backendNameEarly() !== "local" && backendNameEarly() !== "solari") {
+  console.error(`unknown --backend "${backendNameEarly()}". Use "local" or "solari".`)
+  process.exit(2)
+}
+
+if (cmd !== "check") {
+  console.error(`usage: prism check [--backend local|solari] [--url URL] [--fix]`)
+  process.exit(2)
+}
+
+const backendName = backendNameEarly()
+const bugs = has("fix")
+  ? { leakExportToFree: false, trackerBeforeConsent: false }
+  : { leakExportToFree: true, trackerBeforeConsent: true }
+
+let site: { url: string; close: () => Promise<void> } | null = null
+let url = flag("url")
+let backend: Backend
+
+if (backendName === "solari") {
+  const apiKey = process.env.SOLARI_API_KEY
+  if (!apiKey) {
+    console.error("SOLARI_API_KEY is not set. `--backend local` needs no credentials.")
+    process.exit(2)
+  }
+  if (url && isLoopback(url)) {
+    console.error(
+      "A cloud browser cannot reach a URL on this machine.\n" +
+      "Drop --url to have Prism host the demo site in a Solari sandbox, or point\n" +
+      "--url at a publicly reachable address.",
+    )
+    process.exit(2)
+  }
+  if (!url) {
+    // Browser and sandbox on the same key: the sandbox serves the demo site on
+    // a public preview URL, which is the only way the cloud browser can see it.
+    console.error("hosting the demo site in a Solari sandbox...")
+    const hosted = await hostInSandbox(apiKey, { fix: has("fix") })
+    site = hosted
+    url = hosted.url
+    console.error(`demo site: ${url} (guest node ${hosted.nodeVersion})`)
+  }
+  // Seed only the profiles Prism itself created for its own demo site. Against
+  // a real target the profiles were enrolled by a human and must not be touched.
+  backend = await solariBackend({ apiKey, seed: site !== null || has("seed") })
+} else {
+  if (!url) {
+    site = await serve(0, bugs)
+    url = site.url
+    console.error(`demo site: ${url}${has("fix") ? " (bugs fixed)" : " (with the two planted bugs)"}`)
+  }
+  backend = await localBackend()
+}
+
+console.error(`backend: ${backend.name}  classes: ${CLASSES.length}\n`)
+
+try {
+  const backpressure: number[] = []
+  const results = await check(backend, url, CLASSES, (e) => {
+    backpressure.push(e.concurrency)
+    console.error(`  backpressure: concurrency now ${e.concurrency}`)
+  })
+
+  // `--proof FILE` writes the run as evidence. A table in a README is a claim;
+  // a committed run with every class's actual testids is something a reader can
+  // check against the code.
+  const proof = flag("proof")
+  if (proof) {
+    mkdirSync(new URL(".", `file://${process.cwd()}/${proof}`).pathname, { recursive: true })
+    writeFileSync(proof, JSON.stringify({
+      backend: backend.name,
+      classes: CLASSES.length,
+      bugsPlanted: !has("fix"),
+      // The signed pt_token is a live credential for the sandbox; record only
+      // the origin so the evidence can be committed.
+      target: url.startsWith("http") ? new URL(url).origin : url,
+      backpressureEvents: backpressure,
+      results: results.map((r) => ({
+        name: r.name, ok: r.ok, saw: r.saw, findings: r.findings, ms: r.ms,
+        ...(r.error ? { error: r.error } : {}),
+      })),
+    }, null, 2) + "\n")
+    console.error(`proof written to ${proof}`)
+  }
+  console.log(table(results))
+  const failed = results.filter((r) => !r.ok)
+  if (failed.length) {
+    console.log(`\n${failed.length} of ${results.length} user classes saw the wrong page:\n`)
+    console.log(explain(results))
+  } else {
+    console.log(`\nall ${results.length} user classes saw exactly what they should.`)
+  }
+  // Exit code: a real check must fail CI when a user class sees the wrong
+  // page. But the DEMO is supposed to find its own planted bugs, and exiting
+  // non-zero there reads as "the example is broken" rather than "it worked".
+  // So the demo reports success for finding exactly what it planted.
+  const isDemo = site !== null && !has("fix")
+  if (isDemo) {
+    // Assert WHAT was found, not merely which classes went red. A class can
+    // fail for the wrong reason and still land in the right bucket.
+    const expected: Record<string, string[]> = {
+      anon: ["tracker"],
+      free: ["export"],
+      "eu-consent-rejected": ["export", "tracker"],
+    }
+    const found = Object.fromEntries(
+      failed.map((r) => [r.name, r.findings.map((f) => f.testid).sort()]),
+    )
+    const asPlanned = JSON.stringify(found, Object.keys(found).sort()) ===
+      JSON.stringify(expected, Object.keys(expected).sort())
+    console.log(asPlanned
+      ? `\nThis is the expected result: the demo site ships those two bugs on purpose,\n` +
+        `and Prism found every class they touch. Run with --fix to serve the\n` +
+        `corrected app and see the same six classes go green.`
+      : `\nUnexpected. Expected ${JSON.stringify(expected)}\n     but found ${JSON.stringify(found)}.`)
+    process.exitCode = asPlanned ? 0 : 1
+  } else {
+    process.exitCode = failed.length ? 1 : 0
+  }
+} finally {
+  await backend.close()
+  await site?.close()
+}

--- a/applications/prism/src/fleet.ts
+++ b/applications/prism/src/fleet.ts
@@ -1,0 +1,91 @@
+/**
+ * Run N probes concurrently without tripping the account's session cap.
+ *
+ * Measured on Starter 2026-09-08: the documented cap is 20, the API accepts 18
+ * and refuses the 19th with
+ *   429 {"code":"ConcurrencyLimitExceeded","cap":20}
+ * (filed upstream). A released slot is reusable in ~300ms.
+ *
+ * So the pool starts below the documented number and shrinks on a 429 rather
+ * than assuming the published figure is right. Retrying a capacity error
+ * immediately is pointless; it needs a slot, not another attempt.
+ *
+ * Two properties have to hold, and both were broken by an earlier hand-rolled
+ * scheduler that counted "admitted" and "running" with one variable:
+ *
+ *   1. Never more than `limit` probes running at once -- INCLUDING a retry.
+ *      A retry that re-enters without re-acquiring pushes straight back over
+ *      the cap that just rejected it.
+ *   2. Never resolve while a probe is still in flight. Resolving early drops
+ *      the retry's result and lets it open a cloud session after the caller
+ *      has closed the backend -- leaking the billable slot this pool exists
+ *      to protect.
+ *
+ * A semaphore plus Promise.all gives both by construction: a probe runs only
+ * while holding a permit, and every task is awaited to completion.
+ */
+export type Task<T> = () => Promise<T>
+export type FleetResult<T> = { value?: T; error?: unknown; attempts: number }
+
+export type FleetOpts = {
+  /** Start here. Default 8: comfortably under the measured 18. */
+  concurrency?: number
+  maxRetries?: number
+  backoffMs?: number
+  isBackpressure?: (err: unknown) => boolean
+  onEvent?: (e: { type: "backpressure"; concurrency: number }) => void
+}
+
+export async function runFleet<T>(tasks: Task<T>[], opts: FleetOpts = {}): Promise<FleetResult<T>[]> {
+  let limit = Math.max(1, opts.concurrency ?? 8)
+  const maxRetries = opts.maxRetries ?? 3
+  const backoffMs = opts.backoffMs ?? 750
+  const isBackpressure = opts.isBackpressure ?? (() => false)
+  const results: FleetResult<T>[] = tasks.map(() => ({ attempts: 0 }))
+
+  let running = 0
+  let waiters: (() => void)[] = []
+
+  const acquire = async () => {
+    // Re-check after every wake: `limit` can shrink while we wait, so a permit
+    // that was free when we were woken may not be free by the time we run.
+    while (running >= limit) await new Promise<void>((r) => waiters.push(r))
+    running++
+  }
+  const release = () => {
+    running--
+    // Wake everyone and let them re-test. Waking exactly one is wrong here:
+    // that one may re-queue (the limit shrank), and then nobody is left to
+    // wake the rest. The queue is at most one entry per task, so this is cheap.
+    const woken = waiters
+    waiters = []
+    for (const w of woken) w()
+  }
+
+  await Promise.all(
+    tasks.map(async (task, i) => {
+      const slot = results[i]!
+      for (;;) {
+        await acquire()
+        slot.attempts++
+        try {
+          slot.value = await task()
+          release()
+          return
+        } catch (err) {
+          release()
+          if (isBackpressure(err) && slot.attempts <= maxRetries) {
+            limit = Math.max(1, limit - 1)
+            opts.onEvent?.({ type: "backpressure", concurrency: limit })
+            await new Promise((r) => setTimeout(r, backoffMs * slot.attempts))
+            continue
+          }
+          slot.error = err
+          return
+        }
+      }
+    }),
+  )
+
+  return results
+}

--- a/applications/prism/src/host.ts
+++ b/applications/prism/src/host.ts
@@ -1,0 +1,113 @@
+/**
+ * Host the demo site inside a Solari sandbox, on a public URL.
+ *
+ * A cloud browser cannot reach `127.0.0.1` on your laptop, so `--backend
+ * solari` has nothing to point at unless the site lives somewhere public.
+ * Rather than ask the reader to deploy something, Prism serves it from a
+ * sandbox and takes the preview URL -- browser and sandbox on the same key,
+ * which is the thing the cookbook's own README calls out about Solari.
+ *
+ * Constraints this is built around, both measured or reported rather than
+ * assumed:
+ *   - The base image ships Node 18 and has no build step (reported in #34), so
+ *     what gets uploaded is the same plain `site.js` / `server.js` the local
+ *     run uses. No TypeScript, no npm install, no second copy of the app.
+ *   - `previewUrl()` returns a URL that is ALREADY signed: the credential is a
+ *     `pt_token` query parameter. Measured 2026-09-08 against a live sandbox:
+ *     the returned URL fetches 200, the same origin without the query is
+ *     `401 invalid preview token`, and the token is rejected as an
+ *     Authorization / x-solari-token header or a cookie. So the query string
+ *     is load-bearing -- rebuild the URL and you lock yourself out. Append
+ *     paths by setting `pathname`, never by concatenation (the trap in #44).
+ */
+import { readFileSync } from "node:fs"
+import { SolariClient } from "@solarisdk/sdk"
+
+export type HostedSite = {
+  url: string
+  /** Node version actually running in the guest, for the record. */
+  nodeVersion: string
+  close: () => Promise<void>
+}
+
+const GUEST_DIR = "/tmp/prism-site"
+const GUEST_PORT = 3000
+
+export async function hostInSandbox(
+  apiKey: string,
+  opts: { fix?: boolean; timeoutMs?: number; readyTimeoutMs?: number } = {},
+): Promise<HostedSite> {
+  const timeoutMs = opts.timeoutMs ?? 10 * 60_000
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 45_000
+
+  const here = new URL("../demo-site/", import.meta.url)
+  const site = readFileSync(new URL("site.js", here), "utf8")
+  const server = readFileSync(new URL("server.js", here), "utf8")
+
+  const client = new SolariClient({ apiKey })
+  const sandbox = await client.sandboxes.create({ template: "base", timeoutMs })
+
+  // Register teardown before anything else can fail: a sandbox that is created
+  // and then orphaned by a throw keeps billing and holds one of the two
+  // concurrent slots a Starter account gets.
+  const close = async () => { await sandbox.kill().catch(() => {}) }
+
+  try {
+    await sandbox.connect()
+
+    const node = await sandbox.commands.run("node", { args: ["--version"] })
+    const nodeVersion = (node.stdout ?? "").trim() || "unknown"
+
+    await sandbox.files.mkdir(GUEST_DIR)
+    await sandbox.files.write(`${GUEST_DIR}/site.js`, site)
+    await sandbox.files.write(`${GUEST_DIR}/server.js`, server)
+    // `server.js` and `site.js` use ESM. Without this the guest's Node treats
+    // a bare `.js` as CommonJS and the import throws.
+    await sandbox.files.write(`${GUEST_DIR}/package.json`, JSON.stringify({ type: "module" }))
+
+    // `commands.run` waits for exit, so the server has to be backgrounded or
+    // it would block until the sandbox idles out.
+    const fixFlag = opts.fix ? " --fix" : ""
+    await sandbox.commands.run("sh", {
+      args: ["-c", `cd ${GUEST_DIR} && nohup node server.js ${GUEST_PORT}${fixFlag} >/tmp/prism-site.log 2>&1 & echo started`],
+    })
+
+    const { url } = await sandbox.previewUrl(GUEST_PORT)
+    // Use it verbatim. `new URL("/", url)` looks harmless and is not: it drops
+    // the signed query and every request then 401s.
+    const ready = url
+
+    const deadline = Date.now() + readyTimeoutMs
+    let lastStatus = "no response"
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(ready)
+        if (res.ok) return { url: ready, nodeVersion, close }
+        lastStatus = `HTTP ${res.status}`
+      } catch (err) {
+        lastStatus = (err as Error).message
+      }
+      await new Promise((r) => setTimeout(r, 1500))
+    }
+
+    // Say what the guest saw rather than just "timed out".
+    const log = await sandbox.files.readText("/tmp/prism-site.log").catch(() => "(no log)")
+    throw new Error(
+      `demo site never became reachable at ${ready} within ${readyTimeoutMs}ms (${lastStatus}).\n` +
+        `guest node ${nodeVersion}, guest log:\n${log}`,
+    )
+  } catch (err) {
+    await close()
+    throw err
+  }
+}
+
+/**
+ * Append a path to a preview URL without losing the signed `pt_token` query.
+ * `previewUrl + "/path"` and `new URL("/path", previewUrl)` both drop it.
+ */
+export function previewPath(previewUrl: string, path: string): string {
+  const u = new URL(previewUrl)
+  u.pathname = path
+  return u.toString()
+}

--- a/applications/prism/src/report.ts
+++ b/applications/prism/src/report.ts
@@ -1,0 +1,25 @@
+/** Render results so a failure explains itself without reading the code. */
+import type { ClassResult } from "./check.js"
+
+export function table(results: ClassResult[]): string {
+  const rows = results.map((r) => {
+    const detail = r.error
+      ? `error: ${r.error}`
+      : r.findings.length === 0
+        ? "as expected"
+        : r.findings.map((f) => (f.kind === "leaked" ? `LEAKED ${f.testid}` : `missing ${f.testid}`)).join(", ")
+    return `| ${r.name} | ${r.ok ? "pass" : "FAIL"} | ${detail} | ${r.ms}ms |`
+  })
+  return [
+    "| user class | verdict | what was wrong | time |",
+    "|---|---|---|---|",
+    ...rows,
+  ].join("\n")
+}
+
+export function explain(results: ClassResult[]): string {
+  return results.filter((r) => !r.ok).map((r) =>
+    `${r.name}: ${r.because}\n  saw: ${r.saw.join(", ") || "(nothing)"}\n  ${
+      r.error ?? r.findings.map((f) => `${f.kind}: ${f.testid}`).join("; ")}`,
+  ).join("\n\n")
+}

--- a/applications/prism/test/check.test.ts
+++ b/applications/prism/test/check.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+import { SolariError } from "@solarisdk/browser"
+import type { Backend } from "../src/backend.js"
+import type { UserClass } from "../src/classes.js"
+import { check, judge } from "../src/check.js"
+
+const cls: UserClass = { name: "x", because: "", cookies: [], mustSee: ["a", "b"], mustNotSee: ["c"] }
+
+describe("judge", () => {
+  it("passes when everything required is present and nothing forbidden is", () => {
+    expect(judge(cls, ["a", "b", "z"])).toEqual([])
+  })
+  it("reports what is missing", () => {
+    expect(judge(cls, ["a"])).toEqual([{ kind: "missing", testid: "b" }])
+  })
+  it("reports what leaked", () => {
+    expect(judge(cls, ["a", "b", "c"])).toEqual([{ kind: "leaked", testid: "c" }])
+  })
+  it("reports both, missing before leaked", () => {
+    expect(judge(cls, ["c"])).toEqual([
+      { kind: "missing", testid: "a" },
+      { kind: "missing", testid: "b" },
+      { kind: "leaked", testid: "c" },
+    ])
+  })
+})
+
+describe("check", () => {
+  // A backend now owns its own backpressure predicate, so check() never has to
+  // know which one it got. The fake declares the SDK's real 429 shape.
+  const fake = (probe: Backend["probe"], isBackpressure?: Backend["isBackpressure"]): Backend =>
+    ({ name: "fake", probe, isBackpressure, close: async () => {} })
+  const solari429 = (e: unknown) => e instanceof SolariError && e.status === 429
+  const classes: UserClass[] = ["p", "q", "r"].map((name) => ({
+    name, because: "", cookies: [], mustSee: ["heading"], mustNotSee: ["admin"],
+  }))
+
+  it("survives the SDK's real 429 on every class and still reports each one", async () => {
+    // The error shape is the SDK's own, so this exercises isConcurrencyLimit
+    // rather than a stand-in predicate. Every class is refused once; each
+    // must be retried and end with a verdict, never `error: undefined`.
+    const refused = new Set<string>()
+    let probes = 0
+    const backend = fake(async (_url, _cookies, label) => {
+      probes++
+      if (!refused.has(label)) {
+        refused.add(label)
+        throw new SolariError("at cap", 429, undefined, "ConcurrencyLimitExceeded")
+      }
+      return { testids: ["heading"], title: "", url: "" }
+    }, solari429)
+    const events: number[] = []
+    const results = await check(backend, "http://example.test/", classes, (e) => events.push(e.concurrency))
+
+    expect(probes).toBe(classes.length * 2)
+    expect(events).toEqual([7, 6, 5])
+    for (const r of results) {
+      expect(r.error).toBeUndefined()
+      expect(r.ok).toBe(true)
+      expect(r.saw).toEqual(["heading"])
+    }
+  })
+
+  it("turns any other error into a failed verdict for that class only", async () => {
+    const backend = fake(async (_url, _cookies, label) => {
+      if (label === "q") throw new Error("navigation timeout")
+      return { testids: ["heading"], title: "", url: "" }
+    })
+    const results = await check(backend, "http://example.test/", classes)
+    expect(results.map((r) => r.ok)).toEqual([true, false, true])
+    expect(results[1]!.error).toContain("navigation timeout")
+  })
+})

--- a/applications/prism/test/classes.test.ts
+++ b/applications/prism/test/classes.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Pins the class list to the app it is checking.
+ *
+ * A `mustSee`/`mustNotSee` list can be wrong in a way that still passes: name
+ * a testid the page never renders in `mustNotSee` and the class is green
+ * forever without checking anything. These tests derive what the page actually
+ * produces from `render()` and judge the classes against that, so an
+ * expectation that has drifted away from the app fails here rather than
+ * silently weakening the check.
+ */
+import { describe, expect, it } from "vitest"
+import { DEFAULT_BUGS, NO_BUGS, render } from "../demo-site/app.js"
+import { CLASSES } from "../src/classes.js"
+import { judge } from "../src/check.js"
+
+/** Everything render() can ever emit, so a typo in a class list is caught. */
+const KNOWN = ["heading", "tier", "consent-banner", "signin", "export", "admin", "quota", "tracker"]
+
+const testidsFor = (cookies: { name: string; value: string }[], bugs: typeof DEFAULT_BUGS) => {
+  const c = Object.fromEntries(cookies.map((k) => [k.name, k.value]))
+  const tier = (["anon", "free", "paid", "admin"].includes(c.tier ?? "") ? c.tier : "anon") as
+    "anon" | "free" | "paid" | "admin"
+  const html = render(tier, c.consent ?? "", bugs)
+  return [...html.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]!)
+}
+
+describe("class definitions", () => {
+  it("gives every class a distinct identity", () => {
+    const keys = CLASSES.map((c) =>
+      JSON.stringify([...c.cookies].sort((a, b) => a.name.localeCompare(b.name))))
+    expect(new Set(keys).size, "two classes share cookies, so one verdict must be wrong").toBe(keys.length)
+  })
+
+  it("only names testids the app can actually render", () => {
+    for (const c of CLASSES) {
+      for (const t of [...c.mustSee, ...c.mustNotSee]) {
+        expect(KNOWN, `${c.name} expects unknown testid "${t}"`).toContain(t)
+      }
+    }
+  })
+
+  it("every class passes against the corrected app", () => {
+    for (const c of CLASSES) {
+      expect(judge(c, testidsFor(c.cookies, NO_BUGS)), `${c.name} should pass when the app is right`)
+        .toEqual([])
+    }
+  })
+
+  it("catches exactly the planted bugs, and names them", () => {
+    const failures = Object.fromEntries(
+      CLASSES.map((c) => [c.name, judge(c, testidsFor(c.cookies, DEFAULT_BUGS))])
+        .filter(([, f]) => (f as unknown[]).length > 0)
+        .map(([n, f]) => [n as string, (f as { testid: string }[]).map((x) => x.testid).sort()]),
+    )
+    // Derived from the two bugs in site.js: the export button leaks to `free`,
+    // and the tracker fires without consent. Every identity those touch must
+    // report them -- including the ones whose headline concern is the other bug.
+    expect(failures).toEqual({
+      anon: ["tracker"],
+      free: ["export"],
+      "eu-consent-rejected": ["export", "tracker"],
+    })
+  })
+})

--- a/applications/prism/test/demo-site.test.ts
+++ b/applications/prism/test/demo-site.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The demo's promise is precise: with the bugs on, exactly `free` and
+ * `eu-consent-rejected` fail; with them off, nothing does. This pins that over
+ * real HTTP (no browser) so a change to the site or the classes cannot quietly
+ * turn the demo into "found something else" -- which the CLI treats as exit 1.
+ */
+import { describe, expect, it } from "vitest"
+import { serve, type DemoSite } from "../demo-site/serve.js"
+import { CLASSES } from "../src/classes.js"
+import { judge } from "../src/check.js"
+
+const testids = (html: string) => [...html.matchAll(/data-testid="([^"]+)"/g)].map((m) => m[1]!)
+
+async function render(site: DemoSite, cookies: { name: string; value: string }[]) {
+  const cookie = cookies.map((c) => `${c.name}=${c.value}`).join("; ")
+  const res = await fetch(site.url, { headers: { cookie } })
+  expect(res.status).toBe(200)
+  return testids(await res.text())
+}
+
+async function failing(site: DemoSite) {
+  const out: string[] = []
+  for (const cls of CLASSES) if (judge(cls, await render(site, cls.cookies)).length) out.push(cls.name)
+  return out
+}
+
+describe("demo site", () => {
+  it("with the planted bugs, exactly anon, free and eu-consent-rejected fail", async () => {
+    const site = await serve(0, { leakExportToFree: true, trackerBeforeConsent: true })
+    try {
+      expect(await failing(site)).toEqual(["anon", "free", "eu-consent-rejected"])
+    } finally {
+      await site.close()
+    }
+  })
+
+  it("with the bugs fixed, every class passes", async () => {
+    const site = await serve(0, { leakExportToFree: false, trackerBeforeConsent: false })
+    try {
+      expect(await failing(site)).toEqual([])
+    } finally {
+      await site.close()
+    }
+  })
+
+  it("treats an unknown tier as anon and serves the tracker as a real script", async () => {
+    const site = await serve(0, { leakExportToFree: false, trackerBeforeConsent: false })
+    try {
+      expect(await render(site, [{ name: "tier", value: "root" }])).toContain("signin")
+      const t = await fetch(new URL("/t.js", site.url))
+      expect(t.status).toBe(200)
+      expect(t.headers.get("content-type")).toBe("application/javascript")
+    } finally {
+      await site.close()
+    }
+  })
+})

--- a/applications/prism/test/fleet.test.ts
+++ b/applications/prism/test/fleet.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The pool's whole job is accounting: never more in flight than the cap allows,
+ * and never resolve while a probe is still running. Both failure modes here
+ * were real: a retry that left the `active` count let the fleet resolve early
+ * (and then fire a probe after the backend had closed), or hang forever.
+ */
+import { describe, expect, it } from "vitest"
+import { runFleet } from "../src/fleet.js"
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+class Cap extends Error {}
+const isCap = (e: unknown) => e instanceof Cap
+
+describe("runFleet", () => {
+  it("returns results in task order, whatever order they finish in", async () => {
+    const r = await runFleet(
+      [async () => { await sleep(30); return "slow" }, async () => "fast"],
+      { concurrency: 2 },
+    )
+    expect(r.map((x) => x.value)).toEqual(["slow", "fast"])
+  })
+
+  it("never has more than `concurrency` tasks in flight", async () => {
+    let inFlight = 0
+    let peak = 0
+    const task = async () => { inFlight++; peak = Math.max(peak, inFlight); await sleep(5); inFlight--; return 1 }
+    await runFleet(Array.from({ length: 10 }, () => task), { concurrency: 3 })
+    expect(peak).toBe(3)
+  })
+
+  it("shrinks the pool on a backpressure error and retries that task", async () => {
+    let calls = 0
+    const events: number[] = []
+    const r = await runFleet(
+      [async () => { if (calls++ === 0) throw new Cap("429"); return "ok" }],
+      { concurrency: 4, backoffMs: 1, isBackpressure: isCap, onEvent: (e) => events.push(e.concurrency) },
+    )
+    expect(r[0]).toEqual({ value: "ok", attempts: 2 })
+    expect(events).toEqual([3])
+  })
+
+  it("after a shrink, no more probes run at once than the new limit allows", async () => {
+    let inFlight = 0
+    let shrunk = false
+    let peakAfterShrink = 0
+    let first = true
+    const task = (label: number) => async () => {
+      if (label === 0 && first) { first = false; throw new Cap("429") }
+      inFlight++
+      if (shrunk) peakAfterShrink = Math.max(peakAfterShrink, inFlight)
+      await sleep(10)
+      inFlight--
+      return label
+    }
+    await runFleet([0, 1, 2, 3, 4].map(task), {
+      concurrency: 2, backoffMs: 1, isBackpressure: isCap, onEvent: () => { shrunk = true },
+    })
+    expect(shrunk).toBe(true)
+    expect(peakAfterShrink).toBe(1)
+  })
+
+  it("does not resolve until a retried task has actually finished", async () => {
+    let calls = 0
+    let retryFinished = false
+    const r = await runFleet(
+      [
+        async () => { if (calls++ === 0) throw new Cap("429"); await sleep(20); retryFinished = true; return "late" },
+        async () => "sibling",
+      ],
+      { concurrency: 2, backoffMs: 5, isBackpressure: isCap },
+    )
+    expect(retryFinished).toBe(true)
+    expect(r[0]).toEqual({ value: "late", attempts: 2 })
+    for (const x of r) expect("value" in x || "error" in x).toBe(true)
+  })
+
+  it("resolves when every task is backpressured once (the 429-shrink path)", async () => {
+    const seen = new Set<number>()
+    const tasks = Array.from({ length: 6 }, (_, i) => async () => {
+      if (!seen.has(i)) { seen.add(i); throw new Cap("429") }
+      return i
+    })
+    const r = await runFleet(tasks, { concurrency: 6, backoffMs: 1, isBackpressure: isCap })
+    expect(r.map((x) => x.value)).toEqual([0, 1, 2, 3, 4, 5])
+    expect(r.every((x) => x.attempts === 2)).toBe(true)
+  })
+
+  it("gives up after maxRetries and reports the error instead of hanging", async () => {
+    const r = await runFleet(
+      [async () => { throw new Cap("429") }],
+      { maxRetries: 2, backoffMs: 1, isBackpressure: isCap },
+    )
+    expect(r[0]!.attempts).toBe(3)
+    expect(r[0]!.error).toBeInstanceOf(Cap)
+  })
+
+  it("does not retry an error that is not backpressure", async () => {
+    const r = await runFleet([async () => { throw new Error("boom") }], { isBackpressure: isCap })
+    expect(r[0]!.attempts).toBe(1)
+    expect(String(r[0]!.error)).toContain("boom")
+  })
+})

--- a/applications/prism/tsconfig.json
+++ b/applications/prism/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "es2023",
+      "dom"
+    ],
+    "allowJs": true
+  },
+  "include": [
+    "src",
+    "test",
+    "demo-site"
+  ]
+}


### PR DESCRIPTION
A web app shows different things to different people: signed out, free, paid, admin, consented, not consented. Getting that wrong is expensive in two directions — a free account that can reach a paid feature is revenue walking out the door, and a visitor who refused cookies but still loads your tracker is a regulatory problem. Almost nobody tests it, because testing it means holding several sets of real credentials and driving several authenticated browsers at the same time.

Prism renders one URL as every user class simultaneously and asserts what each one **actually saw**.

### Watch it — no credentials needed

```bash
npm install && npx playwright install chromium
npm run demo
```

The demo site ships two deliberate bugs:

```
| user class | verdict | what was wrong | time |
|---|---|---|---|
| anon | FAIL | LEAKED tracker | 351ms |
| free | FAIL | LEAKED export | 350ms |
| paid | pass | as expected | 345ms |
| admin | pass | as expected | 351ms |
| eu-consent-rejected | FAIL | LEAKED tracker, LEAKED export | 347ms |
| anon-consent-accepted | pass | as expected | 350ms |
```

Two bugs surfacing on three identities. `npm run demo -- --fix` serves the corrected app and all six pass.

### How it decides

Every verdict comes from `data-testid` attributes read off a live page after a real HTTP navigation. Nothing asserts that a profile attached or that a cookie was set — those can all be true while the user still sees the wrong page. Each class declares what it must see, must not see, and why:

```ts
{
  name: "free",
  mustSee: ["heading", "quota"],
  mustNotSee: ["export", "admin"],
  because: "a free account must not reach paid-only export -- this is revenue leak",
}
```

The `because` line prints on failure, so a red run explains itself without anyone reading the source.

Two rules the class list has to obey, both learned by breaking them. No two classes may share an identity, or the same page gets judged twice by different standards and one verdict is wrong by construction. And every class must reject everything it should never see, not just its headline concern — an earlier version let `anon` pass with the tracker on screen because tracking was "someone else's row".

### The Solari part

The honest claim is not "many browsers at once" — a laptop can run twenty Playwright contexts with twenty `storageState` objects. It is **where the session lives**. A Solari profile is server-side: a human populates it once in the console's live browser, clearing 2FA and a captcha by hand, and every run after needs only `SOLARI_API_KEY`. Local Playwright cannot do this; the credential has to exist somewhere you control — a secret store, a committed cookie jar, a file on the runner. Prism's check phase never holds one.

A cloud browser cannot reach `127.0.0.1`, so with no `--url` Prism serves the demo site from a Solari **sandbox** and points the browsers at its public preview URL — sandbox and browsers on one key. Point `--url` at a real deployment to check your own app.

Verified live on 2026-09-08 (Starter): six cloud browsers, six server-side profiles, sandbox-hosted site. Same verdicts as the local run on all six classes, ~8.1s per class. Both runs are committed in `proof/`.

Two traps that cost me time, in case they save you some:

- `previewUrl()` returns a URL whose credential is a `pt_token` **query parameter**. Fetching the same origin without it is `401 invalid preview token`, and the token is rejected as an `Authorization` header, an `x-solari-token` header, and a cookie. Rebuilding the URL — even `new URL("/", url)` — locks you out.
- The base sandbox image runs Node 18 with no build step, so the site uploaded to it is the same plain `demo-site/site.js` the local run uses. One file, so the cloud cannot quietly serve a different app than the one you checked.

### What this does not do

- **The demo site is ours.** This proves the mechanism, not that a real paywall was defeated. Pointing `--url` at a real app is the one config change.
- **No anti-bot claim.** Stealth returned `503 {"error":"No stealth pool available","fleet":"empty"}`, and proxy requires stealth, so neither was exercised.
- **No replay evidence.** `recording: true` produced no replay on `kind: "fast"` in 29 sessions (#55), so Prism's evidence is its own `proof/` files.
- **The tracker check is DOM presence,** not a network assertion. A tracker injected later by script would need a request-level check. Solari can do that over raw CDP — see `eu-consent-evidence-ts` — and Prism deliberately does not, because a DOM check should be honest about being one.
- **~18 concurrent, not 20.** Measured; the 429 body says `"cap":20` (#57). `runFleet` starts below the published number and shrinks on backpressure rather than trusting it.

### Housekeeping

- One `SOLARI_API_KEY` and nothing else. No second vendor, no model anywhere.
- `--backend local` needs no credentials at all; `npm test` is 21 tests with none.
- Nothing outside `applications/prism/` changes except one row in the applications table.
- Against a real target Prism refuses to run unless the profile already exists, rather than overwriting a session a human enrolled by hand. `--seed` is opt-in and nothing else turns it on.

21 tests passing and the demo re-verified on 2026-09-09.
